### PR TITLE
Corrected JSON data format when sending message

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -16,7 +16,7 @@ exports = module.exports = Constants = {
 
   'PARAM_DELAY_WHILE_IDLE' : 'delay_while_idle',
 
-  'PARAM_PAYLOAD_PREFIX' : 'data.',
+  'PARAM_PAYLOAD_KEY' : 'data',
 
   'PARAM_TIME_TO_LIVE' : 'time_to_live',
 

--- a/lib/message.js
+++ b/lib/message.js
@@ -11,8 +11,10 @@ function Message () {
     this.delayWhileIdle = undefined;
     this.timeToLive = undefined;
     this.data = {};
+	this.hasData = false;
 };
 
 Message.prototype.addData = function(key, value) {
+	this.hasData = true;
 	this.data[key] = value;
 };

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -55,8 +55,8 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function(message, registr
 	if (message.collapseKey !== undefined) {
 		body[Constants.PARAM_COLLAPSE_KEY] = message.collapseKey;
 	}
-	for (var data in message.data) {
-		body[Constants.PARAM_PAYLOAD_PREFIX + data] = message.data[data];
+	if (message.hasData) {
+		body[Constants.PARAM_PAYLOAD_KEY] = message.data;
 	}
 
 	var requestBody = JSON.stringify(body);


### PR DESCRIPTION
Hello, Thanks for the Node.js module!

I found an issue when passing data to a GCM message. The JSON needs to have data as a main key, then the payload needs to be sub-keys.

Please review my changes or implement something similar in your main repository.

{
  "registration_id" : "APA91bHun4MxP5egoKMwt2KZFBaFUH-1RYqx...",
  "data" : {
    "foo" : "bar"
  },
}
