### PR TITLE
Added error handler to HTTPS request to handle DNS exceptions

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -144,6 +144,11 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function(message, registr
     	});
 	});
 
+	post_req.on('error', function(e) {
+		console.log("Exception during GCM request: " + e);
+		callback();
+	});
+
   	post_req.write(requestBody);
   	post_req.end();
 };


### PR DESCRIPTION
Hello again,

I made another small fix to handle exceptions thrown by the HTTPS request, such as failed DNS resolutions. This can happen if the internet connection is temporarily down on the server.

Without this fix, Node.js simply shuts down because of an unhandled exception.

The error handler simply logs the error and triggers the normal retry process with exponential backoff.

You can test the change by setting 'GCM_SEND_ENDPOINT' : 'android.googleapis1234.com' and sending a GCM message.
