### PR TITLE
Fix content-length header

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -104,7 +104,7 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function(message, registr
       	method: 'POST',
       	headers: {
           	'Content-Type' : 'application/json',
-          	'Content-length' : requestBody.length,
+          	'Content-length' : Buffer.byteLength(requestBody, 'utf8'),
           	'Authorization' : 'key=' + this.key
       	}
   	};


### PR DESCRIPTION
The content-length header should be set in bytes length, not the length of the json in character.
