### PR TITLE
Do not parse the buffer for failed requests.

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -120,8 +120,6 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function(message, registr
     	});
     
     	res.on('end', function () {
-      		var data = JSON.parse(buf);
-      		
       		if (statusCode === 503) {
         		console.log('GCM service is unavailable');
         		callback();
@@ -131,6 +129,8 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function(message, registr
         		callback();
       		}
 
+      		var data = JSON.parse(buf);
+      		
       		if (registrationIds.length === 1) {
         		if(data.results[0].message_id)
           			result.messageId = data.results[0].message_id;


### PR DESCRIPTION
This fixes an issue where GCM returns responses that aren't valid JSON, like the response below for 401 Unauthorized:

<HTML>
<HEAD>
<TITLE>Unauthorized</TITLE>
</HEAD>
<BODY BGCOLOR="#FFFFFF" TEXT="#000000">

<H1>Unauthorized</H1>

<H2>Error 401</H2>

</BODY>
</HTML>
