### PR TITLE
Wrap response handling in a try/catch to better handle errors.

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -145,6 +145,7 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function(message, registr
 	      		else callback(data);
       		} catch(e) {
       			console.log("Error handling GCM response " + e);
+      			callback();
       		}
     	});
 	});


### PR DESCRIPTION
I am very paranoid so this wraps the response handling in a try/catch -- just in case there is a 200 response with non-json data, or if the data format changes.
