### PR TITLE
Payload values MUST be strings enclosed in quotes according to GCM spec.

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -16,5 +16,5 @@ function Message () {
 
 Message.prototype.addData = function(key, value) {
 	this.hasData = true;
-	this.data[key] = value;
+	this.data[key] = value.toString();
 };


### PR DESCRIPTION
Hi,

I started receiving an error from the GCM server today because I passed an integer value in the data payload. The GCM spec at http://developer.android.com/guide/google/gcm/gcm.html says "Note that the values must be enclosed by strings." I made a change to force the data to a string.
