### PR TITLE
Aggregated callback 'err' parameter missing

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -97,7 +97,7 @@ Sender.prototype.send = function (message, registrationId, retries, callback) {
 
     if (registrationId.length === 1) {
 
-        this.sendNoRetry(message, registrationId, function lambda(result) {
+        this.sendNoRetry(message, registrationId, function lambda(err, result) {
 
             if (result === undefined) {
                 if (attempt < retries) {


### PR DESCRIPTION
Missing parameter was provoking a 'null' string displayed in console instead returned GCM information
