### PR TITLE
Adding timeout for gcm network calls

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -66,7 +66,9 @@ var Constants = {
 
     'BACKOFF_INITIAL_DELAY' : 1000,
 
-    'MAX_BACKOFF_DELAY' : 1024000
+    'MAX_BACKOFF_DELAY' : 1024000  ,
+
+    'SOCKET_TIMEOUT' : 180000 //three minutes
 };
 
 module.exports = Constants;

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -10,8 +10,9 @@ var https = require('https');
 var timer = require('timers');
 
 
-function Sender(key) {
+function Sender(key , options) {
     this.key = key;
+    this.options = options ;
 }
 
 var sendNoRetryMethod = Sender.prototype.sendNoRetry = function (message, registrationIds, callback) {
@@ -19,7 +20,8 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function (message, regist
         result = new Result(),
         requestBody,
         post_options,
-        post_req;
+        post_req,
+        timeout;
 
     body[Constants.JSON_REGISTRATION_IDS] = registrationIds;
 
@@ -78,6 +80,19 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function (message, regist
                 console.log("Error handling GCM response " + e);
                 callback("error", null);
             }
+        });
+    });
+
+    timeout = Constants.SOCKET_TIMEOUT;
+
+    if(this.options && this.options.timeout){
+        timeout =  this.options.timeout;
+    }
+
+    post_req.on('socket', function (socket) {
+        socket.setTimeout(timeout);
+        socket.on('timeout', function() {
+            post_req.abort();
         });
     });
 


### PR DESCRIPTION
Currently there is no timeout set for node gcm network calls. Adding timeout for gcm network calls. 
