### PR TITLE
move callback outside of try catch block

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -75,11 +75,11 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function (message, regist
             // handling the response.
             try {
                 var data = JSON.parse(buf);
-                callback(null, data);
             } catch (e) {
                 console.log("Error handling GCM response " + e);
-                callback("error", null);
+                return callback("error", null);;
             }
+            callback(null, data);
         });
     });
 


### PR DESCRIPTION
Fixes issue #34
If there is an exception within the callback the try-catch block will catch the exception and call the callback a second time, this time with an unrelated error. Moving the callback outside of the try-catch block solves this issue.
