### PR TITLE
Added a call of a callback function in case when no registration id were given.

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -153,6 +153,7 @@ Sender.prototype.send = function (message, registrationId, retries, callback) {
         });
     } else {
         console.log('No RegistrationIds given!');
+        callback('No RegistrationIds given!', null);
     }
 };
 


### PR DESCRIPTION
In case of no registration ids were passed to the 'send' function, the callback was not called, and therefore all the processing depending on callback getting called was stopped.
