### PR TITLE
Added dry_run message parameter

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -22,6 +22,8 @@ var Constants = {
 
     'PARAM_TIME_TO_LIVE' : 'time_to_live',
 
+    'PARAM_DRY_RUN' : 'dry_run',
+
     'ERROR_QUOTA_EXCEEDED' : 'QuotaExceeded',
 
     'ERROR_DEVICE_QUOTA_EXCEEDED' : 'DeviceQuotaExceeded',

--- a/lib/message.js
+++ b/lib/message.js
@@ -10,11 +10,13 @@ function Message(obj) {
         this.collapseKey = obj.collapseKey || undefined;
         this.delayWhileIdle = obj.delayWhileIdle || undefined;
         this.timeToLive = obj.timeToLive || undefined;
+        this.dryRun = obj.dryRun || undefined;
         this.data = obj.data || {};
     } else {
         this.collapseKey = undefined;
         this.delayWhileIdle = undefined;
         this.timeToLive = undefined;
+        this.dryRun = undefined;
         this.data = {};
     }
     if (Object.keys(this.data).length > 0) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -34,6 +34,9 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function (message, regist
     if (message.timeToLive !== undefined) {
         body[Constants.PARAM_TIME_TO_LIVE] = message.timeToLive;
     }
+    if (message.dryRun !== undefined) {
+        body[Constants.PARAM_DRY_RUN] = message.dryRun;
+    }
     if (message.hasData) {
         body[Constants.PARAM_PAYLOAD_KEY] = message.data;
     }


### PR DESCRIPTION
I wanted to be able to use the dry_run message parameter as defined at http://developer.android.com/google/gcm/server.html for my development and implemented it in your library. Hope you can include it.

Thanks!
