### PR TITLE
keep this on Sender object in retries

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -12,7 +12,7 @@ function Sender(key , options) {
     this.options = options;
 }
 
-var sendNoRetryMethod = Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
+Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
     var body = {},
         requestBody,
         post_options,
@@ -103,7 +103,8 @@ var sendNoRetryMethod = Sender.prototype.sendNoRetry = function(message, registr
 Sender.prototype.send = function(message, registrationId, retries, callback) {
 
     var attempt = 0,
-        backoff = Constants.BACKOFF_INITIAL_DELAY;
+        backoff = Constants.BACKOFF_INITIAL_DELAY,
+        self = this;
 
     if (registrationId.length === 1) {
 
@@ -116,7 +117,7 @@ Sender.prototype.send = function(message, registrationId, retries, callback) {
                         sleepTime = Constants.MAX_BACKOFF_DELAY;
                     }
                     setTimeout(function () {
-                        sendNoRetryMethod(message, registrationId, lambda);
+                        self.sendNoRetry(message, registrationId, lambda);
                     }, sleepTime);
                 } else {
                     debug('Could not send message after ' + retries + ' attempts');
@@ -155,7 +156,7 @@ Sender.prototype.send = function(message, registrationId, retries, callback) {
                 registrationId = unsentRegIds;
                 if (registrationId.length !== 0) {
                     setTimeout(function () {
-                        sendNoRetryMethod(message, registrationId, lambda);
+                        self.sendNoRetry(message, registrationId, lambda);
                     }, sleepTime);
                     attempt += 1;
                 } else {


### PR DESCRIPTION
I use node-gcm behind a proxy. Setting the `proxy` option in the `Sender` constructor only works for the initial call to `sendNoRetry`. The retries pass the global object as `this` because they are called via the `sendNoRetryMethod`. I replaced these calls with `self.sendNoRetry` to pass the correct `this`.
