### PR TITLE
Make the callbacks for Sender#{send,sendNoRetry} optional

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -109,6 +109,9 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
 };
 
 Sender.prototype.send = function(message, registrationId, retries, callback) {
+    if(!callback) {
+        callback = function() {};
+    }
 
     var attempt = 0,
         backoff = Constants.BACKOFF_INITIAL_DELAY,

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -17,6 +17,10 @@ function Sender(key , options) {
 }
 
 Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
+    if(!callback) {
+        callback = function() {};
+    }
+
     var body = {},
         requestBody,
         post_options,


### PR DESCRIPTION
Sometimes you'll want to just send something, and not care if it succeeds. That will now be possible.

The following will no longer throw an exception:

```javascript
sender.sendNoRetry(message, registrationIds);
sender.send(message, registrationIds, 4);
```