### PR TITLE
Multi-purpose addData

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -21,7 +21,17 @@ function Message(obj) {
     this.data = obj.data || {};
 }
 
-Message.prototype.addData = Message.prototype.addDataWithKeyValue = function (key, value) {
+Message.prototype.addData = function() {
+    if(arguments.length == 1) {
+        return this.addDataWithObject(arguments[0]);
+    }
+    if(arguments.length == 2) {
+        return this.addDataWithKeyValue(arguments[0], arguments[1]);
+    }
+    throw new Error("Invalid number of arguments given to addData ("+arguments.length+")");
+};
+
+Message.prototype.addDataWithKeyValue = function (key, value) {
     this.data[key] = value;
 };
 

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -51,11 +51,6 @@ describe('UNIT Message', function () {
   });
 
   describe('addData()', function () {
-    it('should be the same as addDataWithKeyValue', function () {
-      var mess = new Message();
-      expect(mess.addData).to.equal(mess.addDataWithKeyValue);
-    });
-
     it('should add properties to the message data object given a key and value', function () {
       var mess = new Message();
       mess.addData('myKey', 'Message');

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -80,6 +80,8 @@ describe('UNIT Message', function () {
       expect(mess.collapseKey).to.not.equal('Message');
       expect(mess.data.collapseKey).to.equal('Message');
     });
+
+    it.skip('should do something if not called properly');
   });
 
   describe('addDataWithObject()', function () {

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -72,6 +72,21 @@ describe('UNIT Message', function () {
     it.skip('should do something if not called properly');
   });
 
+  describe('addDataWithKeyValue()', function () {
+    it('should add properties to the message data object given a key and value', function () {
+      var mess = new Message();
+      mess.addDataWithKeyValue('myKey', 'Message');
+      expect(mess.data.myKey).to.equal('Message');
+    });
+
+    it('should only set values on data object, not top level message', function () {
+      var mess = new Message();
+      mess.addDataWithKeyValue('collapseKey', 'Message');
+      expect(mess.collapseKey).to.not.equal('Message');
+      expect(mess.data.collapseKey).to.equal('Message');
+    });
+  });
+
   describe('addDataWithObject()', function () {
     it('should set the data property to the object passed in', function () {
       var mess = new Message();

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -64,6 +64,46 @@ describe('UNIT Message', function () {
       expect(mess.data.collapseKey).to.equal('Message');
     });
 
+    it('should set the data property to the object passed in', function () {
+      var mess = new Message();
+      var obj = {
+        message: 'hello',
+        key: 'value'
+      };
+      mess.addData(obj);
+      expect(mess.data).to.deep.equal(obj);
+    });
+
+    it('should overwrite data object when an object is passed in', function () {
+      var data = {
+        message: 'hello',
+        key: 'value'
+      };
+      var mess = new Message({ data: { message: 'bye', prop: 'none' } });
+      mess.addData(data);
+      expect(mess.data).to.deep.equal(data);
+    });
+
+    it('should not overwrite data if not passed an object', function () {
+      var data = {
+        message: 'hello',
+        key: 'value'
+      };
+      var mess = new Message({ data: data });
+      mess.addData('adding');
+      expect(mess.data).to.deep.equal(data);
+    });
+
+    it('should not overwrite data if passed an empty object', function () {
+      var data = {
+        message: 'hello',
+        key: 'value'
+      };
+      var mess = new Message({ data: data });
+      mess.addData({});
+      expect(mess.data).to.deep.equal(data);
+    });
+
     it.skip('should do something if not called properly');
   });
 


### PR DESCRIPTION
This PR makes `addData` work as `addDataWithKeyValue` or `addDataWithObject` depending on the number of arguments given.

This results in cleaner syntax if people insist on using `addData*` (instead of setting all values at time of construction).