### PR TITLE
Pass on response body with error information (similar to #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Any help is much appreciated!
  * [Ivan Longin](https://github.com/ilongin)
  * [Paul Bininda](https://github.com/pbininda)
  * [Niels Roesen Abildgaard](https://github.com/hypesystem)
+ * [Leonhardt Wille](https://github.com/lwille)
 
 ## License 
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -92,7 +92,7 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
             return callback(res.statusCode, null);
         } else if (res.statusCode !== 200) {
             debug('Invalid request (' + res.statusCode + '): ' + resBody);
-            return callback(res.statusCode, null);
+            return callback(res.statusCode, resBody);
         }
 
         // Make sure that we don't crash in case something goes wrong while
@@ -126,7 +126,7 @@ Sender.prototype.send = function(message, registrationId, retries, callback) {
                 // if we err'd resend them all
                 if (err) {
                     unsentRegIds = registrationId;
-                } 
+                }
                 // success but check for bad ids
                 else {
                     for (i = 0; i < registrationId.length; i += 1) {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,10 @@
     {
       "name": "Niels Roesen Abildgaard",
       "email": "niels.abildgaard@gmail.com"
+    },
+    {
+      "name": "Leonhardt Wille",
+      "email": "leonhardt.wille@erasys.de"
     }
   ],
   "repository": {


### PR DESCRIPTION
While #79 adds some more sophisticated error handling, we were just interested in the response body in case of an error 400 (resBody was "Number of messages on bulk <nnnn> exceeds maximum allowed (1000)" in our case).