### PR TITLE
Bump devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,10 +120,10 @@
     "debug": "^0.8.1"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
-    "mocha": "^1.21.0",
-    "proxyquire": "^1.0.1",
-    "sinon": "^1.10.3"
+    "chai": "^2.2.0",
+    "mocha": "^2.2.4",
+    "proxyquire": "^1.4.0",
+    "sinon": "^1.14.1"
   },
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
This removes the deprecation warning when running tests.

`chai` and `mocha` are the only changes that actually brings in another version. The other deps were installing latest.

> "request" can be updated from ^2.27.0 to ^2.55.0 (Installed: 2.55.0, Latest: 2.55.0)
"debug" can be updated from ^0.8.1 to ^2.1.3 (Installed: 0.8.1, Latest: 2.1.3)
"chai" can be updated from ^1.9.1 to ^2.2.0 (Installed: 1.10.0, Latest: 2.2.0)
"mocha" can be updated from ^1.21.0 to ^2.2.4 (Installed: 1.21.5, Latest: 2.2.4)
"proxyquire" can be updated from ^1.0.1 to ^1.4.0 (Installed: 1.4.0, Latest: 1.4.0)
"sinon" can be updated from ^1.10.3 to ^1.14.1 (Installed: 1.14.1, Latest: 1.14.1)