### PR TITLE
prevent recursion when errors are thrown in `send()` callback

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -23,7 +23,7 @@ var parseAndRespond = function(resBody, callback) {
         resBodyJSON = JSON.parse(resBody);
     } catch (e) {
         debug("Error parsing GCM response " + e);
-        callback("error", null);
+        callback("Error parsing GCM response");
         return;
     }
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -16,6 +16,20 @@ function Sender(key , options) {
     this.options = options;
 }
 
+var parseAndRespond = function(resBody, callback) {
+    var resBodyJSON;
+
+    try {
+        resBodyJSON = JSON.parse(resBody);
+    } catch (e) {
+        debug("Error parsing GCM response " + e);
+        callback("error", null);
+        return;
+    }
+
+    callback(null, resBodyJSON);
+};
+
 Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
     if(!callback) {
         callback = function() {};
@@ -79,8 +93,6 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
     post_options.timeout = timeout;
 
     post_req = req(post_options, function (err, res, resBody) {
-        var resBodyJSON;
-
         if (err) {
             return callback(err, null);
 
@@ -100,15 +112,7 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
             return callback(res.statusCode, null);
         }
 
-        try {
-            resBodyJSON = JSON.parse(resBody);
-        } catch (e) {
-            debug("Error handling GCM response " + e);
-            callback("error", null);
-            return;
-        }
-
-        callback(null, resBodyJSON);
+        parseAndRespond(resBody, callback);
     });
 };
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -79,6 +79,7 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
     post_options.timeout = timeout;
 
     post_req = req(post_options, function (err, res, resBody) {
+        var resBodyJSON;
 
         if (err) {
             return callback(err, null);
@@ -100,11 +101,14 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
         }
 
         try {
-            callback(null, JSON.parse(resBody));
+            resBodyJSON = JSON.parse(resBody);
         } catch (e) {
             debug("Error handling GCM response " + e);
             callback("error", null);
+            return;
         }
+
+        callback(null, resBodyJSON);
     });
 };
 

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -31,7 +31,7 @@ describe('UNIT Sender', function () {
         maxSockets: 100,
         timeout: 100
       };
-      var key = 'myAPIKey', 
+      var key = 'myAPIKey',
           sender = new Sender(key, options);
       expect(sender).to.be.instanceOf(Sender);
       expect(sender.key).to.equal(key);
@@ -154,7 +154,7 @@ describe('UNIT Sender', function () {
       setArgs(null, { statusCode: 200 }, "non-JSON string.");
       sender.sendNoRetry({ data: {} }, '', callback);
       expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][0]).to.be.a('string');
+      expect(callback.args[0][0]).to.eq('Error parsing GCM response');
     });
 
     it('should pass in parsed resBody into callback on success', function () {


### PR DESCRIPTION
fixes #122