### PR TITLE
support use of direct notification payloads

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -18,6 +18,8 @@ var Constants = {
 
     'PARAM_DELAY_WHILE_IDLE' : 'delay_while_idle',
 
+    'PARAM_NOTIFICATION_KEY' : 'notification',
+
     'PARAM_PAYLOAD_KEY' : 'data',
 
     'PARAM_TIME_TO_LIVE' : 'time_to_live',

--- a/lib/message.js
+++ b/lib/message.js
@@ -21,6 +21,21 @@ function Message(obj) {
     this.data = obj.data || {};
 }
 
+Message.prototype.setNotification = function(title, icon, options) {
+    this.notification = {
+        title: title,
+        icon: icon
+    };
+    if (options !== undefined) {
+        var k;
+        for (k in options) {
+            if (options.hasOwnProperty(k)) {
+                this.notification[k] = options[k];
+            }
+        }
+    }
+};
+
 Message.prototype.addData = function() {
     if(arguments.length == 1) {
         var obj = arguments[0];

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -59,6 +59,9 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
     if (message.dryRun !== undefined) {
         body[Constants.PARAM_DRY_RUN] = message.dryRun;
     }
+    if (message.notification !== undefined) {
+        body[Constants.PARAM_NOTIFICATION_KEY] = message.notification;
+    }
     if (Object.keys(message.data)) {
         body[Constants.PARAM_PAYLOAD_KEY] = message.data;
     }


### PR DESCRIPTION
Offer the option to let Android display notifications on behalf of the client app instead of requiring the client app to process the data-only notification content itself.