### PR TITLE
Delegate responsibility of serialization to Message

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -12,20 +12,6 @@ var Constants = {
 
     'GCM_SEND_URI' : 'https://android.googleapis.com:443/gcm/send',
 
-    'PARAM_REGISTRATION_ID' : 'registration_id',
-
-    'PARAM_COLLAPSE_KEY' : 'collapse_key',
-
-    'PARAM_DELAY_WHILE_IDLE' : 'delay_while_idle',
-
-    'PARAM_PAYLOAD_KEY' : 'data',
-
-    'PARAM_NOTIFICATION_KEY' : 'notification',
-
-    'PARAM_TIME_TO_LIVE' : 'time_to_live',
-
-    'PARAM_DRY_RUN' : 'dry_run',
-
     'ERROR_QUOTA_EXCEEDED' : 'QuotaExceeded',
 
     'ERROR_DEVICE_QUOTA_EXCEEDED' : 'DeviceQuotaExceeded',

--- a/lib/message-options.js
+++ b/lib/message-options.js
@@ -20,7 +20,7 @@ module.exports = {
     //priority (number),
     //content_available (boolean),
 	delayWhileIdle: {
-        __argName: "content_available",
+        __argName: "delay_while_idle",
         __argType: "boolean"
     },
     timeToLive: {

--- a/lib/message-options.js
+++ b/lib/message-options.js
@@ -1,0 +1,43 @@
+/**
+ * This module defines all the arguments that may be passed to a message.
+ * 
+ * Each argument may contain a field `__argName`, if the name of the field
+ * should be different when sent to the server.
+ * 
+ * The argument may also contain a field `__argType`, if the given
+ * argument must be of that type. The types are the strings resulting from
+ * calling `typeof <arg>` where `<arg>` is the argument.
+ * 
+ * Other than that, the arguments are expected to follow the indicated
+ * structure.
+ */
+
+module.exports = {
+	collapseKey: {
+        __argName: "collapse_key",
+        __argType: "string"
+    },
+    //priority (number),
+    //content_available (boolean),
+	delayWhileIdle: {
+        __argName: "content_available",
+        __argType: "boolean"
+    },
+    timeToLive: {
+        __argName: "time_to_live",
+        __argType: "number"
+    },
+    //restricted_package_name (string),
+    dryRun: {
+        __argName: "dry_run",
+        __argType: "boolean"
+    },
+    data: {
+        __argType: "object"
+    },
+    notification: {
+        __argType: "object"
+        //TODO: There are a lot of very specific arguments that could
+        //      be indicated here.
+    }
+};

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,10 +1,3 @@
-/*!
- * node-gcm
- * Copyright(c) 2013 Marcus Farkas <toothlessgear@finitebox.com>
- * MIT Licensed
- */
-
-
 function Message(raw) {
     if (!(this instanceof Message)) {
         return new Message(raw);

--- a/lib/message.js
+++ b/lib/message.js
@@ -67,7 +67,23 @@ Message.prototype.addDataWithObject = function (obj) {
 };
 
 Message.prototype.toJson = function() {
-    return this.params;
+    var json = {};
+
+    Object.keys(this.params).forEach(function(param) {
+        if(messageOptions[param]) {
+            var key = param;
+            var value = this.params[param];
+
+            var optionDescription = messageOptions[param];
+            if(optionDescription.__argName) {
+                key = optionDescription.__argName;
+            }
+
+            json[key] = value;
+        }
+    }.bind(this));
+
+    return json;
 };
 
 module.exports = Message;

--- a/lib/message.js
+++ b/lib/message.js
@@ -5,21 +5,21 @@
  */
 
 
-function Message(obj) {
+function Message(raw) {
     if (!(this instanceof Message)) {
-        return new Message(obj);
+        return new Message(raw);
     }
 
-    if (!obj) {
-        obj = {};
+    if (!raw) {
+        raw = {};
     }
 
-    this.collapseKey = obj.collapseKey || undefined;
-    this.delayWhileIdle = obj.delayWhileIdle || undefined;
-    this.timeToLive = obj.timeToLive || undefined;
-    this.dryRun = obj.dryRun || undefined;
-    this.data = obj.data || {};
-    this.notification = obj.notification || {};
+    this.collapseKey = raw.collapseKey || undefined;
+    this.delayWhileIdle = raw.delayWhileIdle || undefined;
+    this.timeToLive = raw.timeToLive || undefined;
+    this.dryRun = raw.dryRun || undefined;
+    this.data = raw.data || {};
+    this.notification = raw.notification || {};
 }
 
 Message.prototype.addNotification = function() {

--- a/lib/message.js
+++ b/lib/message.js
@@ -59,4 +59,8 @@ Message.prototype.addDataWithObject = function (obj) {
     this.addData(obj);
 };
 
+Message.prototype.toJson = function() {
+    return this.params;
+};
+
 module.exports = Message;

--- a/lib/message.js
+++ b/lib/message.js
@@ -8,7 +8,7 @@ function Message(raw) {
     if (!raw) {
         raw = {};
     }
-    
+
     this.params = {};
 
     this.params.collapseKey = raw.collapseKey || undefined;

--- a/lib/message.js
+++ b/lib/message.js
@@ -30,6 +30,9 @@ Message.prototype.addNotification = function() {
     }
     if(arguments.length == 2) {
         var key = arguments[0], value = arguments[1];
+        if(!this.params.notification) {
+            this.params.notification = {};
+        }
         return this.params.notification[key] = value;
     }
     throw new Error("Invalid number of arguments given to addNotification ("+arguments.length+")");
@@ -45,6 +48,9 @@ Message.prototype.addData = function() {
     }
     if(arguments.length == 2) {
         var key = arguments[0], value = arguments[1];
+        if(!this.params.data) {
+            this.params.data = {};
+        }
         return this.params.data[key] = value;
     }
     throw new Error("Invalid number of arguments given to addData ("+arguments.length+")");

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,3 +1,5 @@
+var messageOptions = require("./message-options");
+
 function Message(raw) {
     if (!(this instanceof Message)) {
         return new Message(raw);
@@ -6,26 +8,28 @@ function Message(raw) {
     if (!raw) {
         raw = {};
     }
+    
+    this.params = {};
 
-    this.collapseKey = raw.collapseKey || undefined;
-    this.delayWhileIdle = raw.delayWhileIdle || undefined;
-    this.timeToLive = raw.timeToLive || undefined;
-    this.dryRun = raw.dryRun || undefined;
-    this.data = raw.data || {};
-    this.notification = raw.notification || {};
+    this.params.collapseKey = raw.collapseKey || undefined;
+    this.params.delayWhileIdle = raw.delayWhileIdle || undefined;
+    this.params.timeToLive = raw.timeToLive || undefined;
+    this.params.dryRun = raw.dryRun || undefined;
+    this.params.data = raw.data || {};
+    this.params.notification = raw.notification || {};
 }
 
 Message.prototype.addNotification = function() {
     if(arguments.length == 1) {
         var obj = arguments[0];
         if (typeof obj === 'object' && Object.keys(obj).length > 0) {
-            this.notification = obj;
+            this.params.notification = obj;
         }
         return;
     }
     if(arguments.length == 2) {
         var key = arguments[0], value = arguments[1];
-        return this.notification[key] = value;
+        return this.params.notification[key] = value;
     }
     throw new Error("Invalid number of arguments given to addNotification ("+arguments.length+")");
 };
@@ -34,13 +38,13 @@ Message.prototype.addData = function() {
     if(arguments.length == 1) {
         var obj = arguments[0];
         if (typeof obj === 'object' && Object.keys(obj).length > 0) {
-            this.data = obj;
+            this.params.data = obj;
         }
         return;
     }
     if(arguments.length == 2) {
         var key = arguments[0], value = arguments[1];
-        return this.data[key] = value;
+        return this.params.data[key] = value;
     }
     throw new Error("Invalid number of arguments given to addData ("+arguments.length+")");
 };

--- a/lib/message.js
+++ b/lib/message.js
@@ -9,14 +9,15 @@ function Message(raw) {
         raw = {};
     }
 
-    this.params = {};
-
-    this.params.collapseKey = raw.collapseKey || undefined;
-    this.params.delayWhileIdle = raw.delayWhileIdle || undefined;
-    this.params.timeToLive = raw.timeToLive || undefined;
-    this.params.dryRun = raw.dryRun || undefined;
-    this.params.data = raw.data || {};
-    this.params.notification = raw.notification || {};
+    var params = {};
+    
+    Object.keys(raw).forEach(function(param) {
+        if(messageOptions[param]) {
+            params[param] = raw[param];
+        }
+    });
+    
+    this.params = params;
 }
 
 Message.prototype.addNotification = function() {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -34,17 +34,12 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
         registrationIds = [registrationIds];
     }
 
-    var requestBody,
-        post_options,
-        post_req,
-        timeout;
-
     var body = message.toJson();
     body[Constants.JSON_REGISTRATION_IDS] = registrationIds;
 
-    requestBody = JSON.stringify(body);
+    var requestBody = JSON.stringify(body);
 
-    post_options = {
+    var post_options = {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -63,7 +58,7 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
         post_options.maxSockets = this.options.maxSockets;
     }
 
-    timeout = Constants.SOCKET_TIMEOUT;
+    var timeout = Constants.SOCKET_TIMEOUT;
 
     if (this.options && this.options.timeout) {
         timeout =  this.options.timeout;
@@ -71,7 +66,7 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
 
     post_options.timeout = timeout;
 
-    post_req = req(post_options, function (err, res, resBody) {
+    var post_req = req(post_options, function (err, res, resBody) {
         if (err) {
             return callback(err, null);
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -7,7 +7,7 @@ var Constants = require('./constants');
 var req = require('request');
 var debug = require('debug')('node-gcm');
 
-function Sender(key , options) {
+function Sender(key, options) {
     if (!(this instanceof Sender)) {
         return new Sender(key, options);
     }

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -34,32 +34,14 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
         registrationIds = [registrationIds];
     }
 
-    var body = {},
-        requestBody,
+    var requestBody,
         post_options,
         post_req,
         timeout;
 
+    var body = message.toJson();
     body[Constants.JSON_REGISTRATION_IDS] = registrationIds;
 
-    if (message.delayWhileIdle !== undefined) {
-        body[Constants.PARAM_DELAY_WHILE_IDLE] = message.delayWhileIdle;
-    }
-    if (message.collapseKey !== undefined) {
-        body[Constants.PARAM_COLLAPSE_KEY] = message.collapseKey;
-    }
-    if (message.timeToLive !== undefined) {
-        body[Constants.PARAM_TIME_TO_LIVE] = message.timeToLive;
-    }
-    if (message.dryRun !== undefined) {
-        body[Constants.PARAM_DRY_RUN] = message.dryRun;
-    }
-    if (Object.keys(message.data)) {
-        body[Constants.PARAM_PAYLOAD_KEY] = message.data;
-    }
-    if (message.notification && Object.keys(message.notification)) {
-        body[Constants.PARAM_NOTIFICATION_KEY] = message.notification;
-    }
     requestBody = JSON.stringify(body);
 
     post_options = {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1,8 +1,3 @@
-/*!
- * node-gcm
- * Copyright(c) 2013 Marcus Farkas <toothlessgear@finitebox.com>
- * MIT Licensed
- */
 var Constants = require('./constants');
 var req = require('request');
 var debug = require('debug')('node-gcm');

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -190,5 +190,55 @@ describe('UNIT Message', function () {
       expect(mess.notification).to.deep.equal(obj);
     });
   });
+  
+  describe('toJson()', function() {
+    it('should return well-formed data for GCM if it is valid', function() {
+      var m = new Message({
+        delayWhileIdle: true,
+        dryRun: true,
+        data: {
+          hello: "world"
+        }
+      });
+
+      var json = m.toJson();
+
+      expect(json.delay_while_idle).to.equal(true);
+      expect(json.dry_run).to.equal(true);
+      expect(json.data.hello).to.equal("world");
+      expect(json.delayWhileIdle).to.be.an("undefined");
+      expect(json.dryRun).to.be.an("undefined");
+    });
+    
+    it('should return well-formed data for GCM if it describes a notification', function() {
+      var notificationData = {
+        title: "Hello, World",
+        icon: 'ic_launcher',
+        body: "This is a quick notification."
+      };
+
+      var m = new Message({ delayWhileIdle: true });
+      m.addNotification(notificationData);
+
+      var json = m.toJson();
+
+      expect(json.delay_while_idle).to.equal(true);
+      expect(json.notification).not.to.be.an("undefined");
+      expect(json.notification).to.deep.equal(notificationData);
+    });
+    
+    it('should ignore non-standard fields when serializing', function() {
+      var m = new Message({
+        timeToLive: 60 * 60 * 24,
+        wrongField: "should be excluded",
+        alsoThisFieldIsWrong: "and should not show up"
+      });
+
+      var json = m.toJson();
+
+      expect(json.time_to_live).to.equal(60 * 60 * 24);
+      expect(Object.keys(json).length).to.equal(1);
+    });
+  });
 
 });

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -55,9 +55,19 @@ describe('UNIT Message', function () {
         notification: {}
       };
       var mess = new Message(obj);
-      expect(JSON.stringify(mess)).to.equal(JSON.stringify(obj));
-      expect(mess.timeToLive).to.be.undefined;
-      expect(mess.dryRun).to.be.undefined;
+
+      var json = mess.toJson();
+
+      expect(json).to.deep.equal({
+        collapse_key: "Message",
+        delay_while_idle: true,
+        data: {
+          score: 98
+        },
+        notification: {}
+      });
+      expect(json.time_to_live).to.be.an("undefined");
+      expect(mess.dry_run).to.be.an("undefined");
     });
   });
 

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -30,7 +30,19 @@ describe('UNIT Message', function () {
         notification: {}
       };
       var mess = new Message(obj);
-      expect(JSON.stringify(mess)).to.equal(JSON.stringify(obj));
+
+      var json = mess.toJson();
+
+      expect(json).to.deep.equal({
+        collapse_key: "Message",
+        delay_while_idle: true,
+        time_to_live: 100,
+        dry_run: true,
+        data: {
+          score: 98
+        },
+        notification: {}
+      });
     });
 
     it('should only set properties passed into constructor', function () {

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -75,14 +75,20 @@ describe('UNIT Message', function () {
     it('should add properties to the message data object given a key and value', function () {
       var mess = new Message();
       mess.addData('myKey', 'Message');
-      expect(mess.data.myKey).to.equal('Message');
+
+      var json = mess.toJson();
+
+      expect(json.data.myKey).to.equal('Message');
     });
 
     it('should only set values on data object, not top level message', function () {
       var mess = new Message();
       mess.addData('collapseKey', 'Message');
-      expect(mess.collapseKey).to.not.equal('Message');
-      expect(mess.data.collapseKey).to.equal('Message');
+
+      var json = mess.toJson();
+
+      expect(json.collapse_key).to.not.equal('Message');
+      expect(json.data.collapseKey).to.equal('Message');
     });
 
     it('should set the data property to the object passed in', function () {
@@ -92,7 +98,10 @@ describe('UNIT Message', function () {
         key: 'value'
       };
       mess.addData(obj);
-      expect(mess.data).to.deep.equal(obj);
+
+      var json = mess.toJson();
+
+      expect(json.data).to.deep.equal(obj);
     });
 
     it('should overwrite data object when an object is passed in', function () {
@@ -102,7 +111,10 @@ describe('UNIT Message', function () {
       };
       var mess = new Message({ data: { message: 'bye', prop: 'none' } });
       mess.addData(data);
-      expect(mess.data).to.deep.equal(data);
+
+      var json = mess.toJson();
+
+      expect(json.data).to.deep.equal(data);
     });
 
     it('should not overwrite data if not passed an object', function () {
@@ -112,7 +124,10 @@ describe('UNIT Message', function () {
       };
       var mess = new Message({ data: data });
       mess.addData('adding');
-      expect(mess.data).to.deep.equal(data);
+
+      var json = mess.toJson();
+
+      expect(json.data).to.deep.equal(data);
     });
 
     it('should not overwrite data if passed an empty object', function () {
@@ -122,7 +137,10 @@ describe('UNIT Message', function () {
       };
       var mess = new Message({ data: data });
       mess.addData({});
-      expect(mess.data).to.deep.equal(data);
+
+      var json = mess.toJson();
+
+      expect(json.data).to.deep.equal(data);
     });
 
     it.skip('should do something if not called properly');
@@ -132,14 +150,20 @@ describe('UNIT Message', function () {
     it('should add properties to the message data object given a key and value', function () {
       var mess = new Message();
       mess.addDataWithKeyValue('myKey', 'Message');
-      expect(mess.data.myKey).to.equal('Message');
+
+      var json = mess.toJson();
+
+      expect(json.data.myKey).to.equal('Message');
     });
 
     it('should only set values on data object, not top level message', function () {
       var mess = new Message();
       mess.addDataWithKeyValue('collapseKey', 'Message');
-      expect(mess.collapseKey).to.not.equal('Message');
-      expect(mess.data.collapseKey).to.equal('Message');
+
+      var json = mess.toJson();
+
+      expect(json.collapse_key).to.not.equal('Message');
+      expect(json.data.collapseKey).to.equal('Message');
     });
 
     it.skip('should do something if not called properly');
@@ -153,7 +177,10 @@ describe('UNIT Message', function () {
         key: 'value'
       };
       mess.addDataWithObject(obj);
-      expect(mess.data).to.deep.equal(obj);
+
+      var json = mess.toJson();
+
+      expect(json.data).to.deep.equal(obj);
     });
 
     it('should overwrite data object when an object is passed in', function () {
@@ -163,7 +190,10 @@ describe('UNIT Message', function () {
       };
       var mess = new Message({ data: { message: 'bye', prop: 'none' } });
       mess.addDataWithObject(data);
-      expect(mess.data).to.deep.equal(data);
+
+      var json = mess.toJson();
+
+      expect(json.data).to.deep.equal(data);
     });
 
     it('should not overwrite data if not passed an object', function () {
@@ -173,7 +203,10 @@ describe('UNIT Message', function () {
       };
       var mess = new Message({ data: data });
       mess.addDataWithObject('adding');
-      expect(mess.data).to.deep.equal(data);
+
+      var json = mess.toJson();
+
+      expect(json.data).to.deep.equal(data);
     });
 
     it('should not overwrite data if passed an empty object', function () {
@@ -183,7 +216,10 @@ describe('UNIT Message', function () {
       };
       var mess = new Message({ data: data });
       mess.addDataWithObject({});
-      expect(mess.data).to.deep.equal(data);
+
+      var json = mess.toJson();
+
+      expect(json.data).to.deep.equal(data);
     });
   });
 
@@ -193,9 +229,12 @@ describe('UNIT Message', function () {
       mess.addNotification('title', 'hello');
       mess.addNotification('icon', 'ic_launcher');
       mess.addNotification('body', 'world');
-      expect(mess.notification.title).to.equal('hello');
-      expect(mess.notification.icon).to.equal('ic_launcher');
-      expect(mess.notification.body).to.equal('world');
+
+      var json = mess.toJson();
+
+      expect(json.notification.title).to.equal('hello');
+      expect(json.notification.icon).to.equal('ic_launcher');
+      expect(json.notification.body).to.equal('world');
     });
 
     it('should set the notification property to the object passed in', function () {
@@ -206,7 +245,10 @@ describe('UNIT Message', function () {
         body: 'world'
       };
       mess.addNotification(obj);
-      expect(mess.notification).to.deep.equal(obj);
+
+      var json = mess.toJson();
+
+      expect(json.notification).to.deep.equal(obj);
     });
   });
   

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -14,7 +14,7 @@ describe('UNIT Message', function () {
 
     it('should call new on constructor if user does not', function () {
       var mess = Message();
-      expect(mess).to.not.be.undefined;
+      expect(mess).to.not.be.an("undefined");
       expect(mess).to.be.instanceOf(Message);
     });
 

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -6,13 +6,10 @@ var Message = require('../../lib/message'),
 
 describe('UNIT Message', function () {
   describe('constructor', function () {
-    it('should create an empty message with a data object if not passed an object', function () {
+    it('can be instantiated with no state', function () {
       var mess = new Message();
-      expect(mess.collapseKey).to.be.undefined;
-      expect(mess.delayWhileIdle).to.be.undefined;
-      expect(mess.timeToLive).to.be.undefined;
-      expect(mess.dryRun).to.be.undefined;
-      expect(mess.data).to.deep.equal({});
+      var json = mess.toJson();
+      expect(json).to.deep.equal({});
     });
 
     it('should call new on constructor if user does not', function () {

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -5,7 +5,8 @@ var chai = require('chai'),
     sinon = require('sinon'),
     proxyquire = require('proxyquire'),
     senderPath = '../../lib/sender',
-    Constants = require('../../lib/constants');
+    Constants = require('../../lib/constants'),
+    Message = require('../../lib/message');
 
 describe('UNIT Sender', function () {
   // Use object to set arguments passed into callback
@@ -58,7 +59,8 @@ describe('UNIT Sender', function () {
         timeout: 1000
       };
       var sender = new Sender('mykey', options);
-      sender.sendNoRetry({ data: {} }, '', function () {});
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', function () {});
       expect(args.options.proxy).to.equal(options.proxy);
       expect(args.options.maxSockets).to.equal(options.maxSockets);
       expect(args.options.timeout).to.equal(options.timeout);
@@ -66,18 +68,20 @@ describe('UNIT Sender', function () {
 
     it('should set the API key of req object if passed in API key', function () {
       var sender = new Sender('myKey');
-      sender.sendNoRetry({ data: {} }, '', function () {});
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', function () {});
       expect(args.options.headers.Authorization).to.equal('key=myKey');
     });
 
     it('should stringify body of req before it is sent', function () {
       var sender = new Sender('mykey');
-      sender.sendNoRetry({ collapseKey: 'Message', data: {} }, '', function () {});
+      var m = new Message({ collapseKey: 'Message', data: {} });
+      sender.sendNoRetry(m, '', function () {});
       expect(args.options.body).to.be.a('string');
     });
 
     it('should set properties of body with message properties', function () {
-      var mess = {
+      var mess = new Message({
         delayWhileIdle: true,
         collapseKey: 'Message',
         timeToLive: 100,
@@ -85,7 +89,7 @@ describe('UNIT Sender', function () {
         data: {
           name: 'Matt'
         }
-      };
+      });
       var sender = new Sender('mykey');
       sender.sendNoRetry(mess, '', function () {});
       var body = JSON.parse(args.options.body);
@@ -98,7 +102,8 @@ describe('UNIT Sender', function () {
 
     it('should set the registration ids to reg ids passed in', function () {
       var sender = new Sender('myKey');
-      sender.sendNoRetry({ data: {} }, 12, function () {});
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, 12, function () {});
       var body = JSON.parse(args.options.body);
       expect(body[Constants.JSON_REGISTRATION_IDS]).to.equal(12);
     });
@@ -107,7 +112,8 @@ describe('UNIT Sender', function () {
       var callback = sinon.spy(),
           sender = new Sender('myKey');
       setArgs('an error', {}, {});
-      sender.sendNoRetry({ data: {} }, '', callback);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', callback);
       expect(callback.calledOnce).to.be.ok;
       expect(callback.calledWith('an error')).to.be.ok;
     });
@@ -116,7 +122,8 @@ describe('UNIT Sender', function () {
       var callback = sinon.spy(),
           sender = new Sender('myKey');
       setArgs(null, undefined, {});
-      sender.sendNoRetry({ data: {} }, '', callback);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', callback);
       expect(callback.calledOnce).to.be.ok;
       expect(callback.args[0][0]).to.be.a('string');
     });
@@ -125,7 +132,8 @@ describe('UNIT Sender', function () {
       var callback = sinon.spy(),
           sender = new Sender('myKey');
       setArgs(null, { statusCode: 500 }, {});
-      sender.sendNoRetry({ data: {} }, '', callback);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', callback);
       expect(callback.calledOnce).to.be.ok;
       expect(callback.args[0][0]).to.equal(500);
     });
@@ -134,7 +142,8 @@ describe('UNIT Sender', function () {
       var callback = sinon.spy(),
           sender = new Sender('myKey');
       setArgs(null, { statusCode: 401 }, {});
-      sender.sendNoRetry({ data: {} }, '', callback);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', callback);
       expect(callback.calledOnce).to.be.ok;
       expect(callback.args[0][0]).to.equal(401);
     });
@@ -143,7 +152,8 @@ describe('UNIT Sender', function () {
       var callback = sinon.spy(),
           sender = new Sender('myKey');
       setArgs(null, { statusCode: 400 }, {});
-      sender.sendNoRetry({ data: {} }, '', callback);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', callback);
       expect(callback.calledOnce).to.be.ok;
       expect(callback.args[0][0]).to.equal(400);
     });
@@ -152,7 +162,8 @@ describe('UNIT Sender', function () {
       var callback = sinon.spy(),
           sender = new Sender('myKey');
       setArgs(null, { statusCode: 200 }, "non-JSON string.");
-      sender.sendNoRetry({ data: {} }, '', callback);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', callback);
       expect(callback.calledOnce).to.be.ok;
       expect(callback.args[0][0]).to.eq('Error parsing GCM response');
     });
@@ -165,7 +176,8 @@ describe('UNIT Sender', function () {
       };
       var sender = new Sender('myKey');
       setArgs(null, { statusCode: 200 }, JSON.stringify(resBody));
-      sender.sendNoRetry({ data: {} }, '', callback);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', callback);
       expect(callback.calledOnce).to.be.ok;
       expect(callback.args[0][1]).to.deep.equal(resBody);
     });


### PR DESCRIPTION
The primary purpose of this PR is to move the responsibility for serializing from *our* abstract representations of Messages to the raw JSON to the `Message`. Previously, this responsibility was in `Sender`, which made extending the set of supported parameters very hard.

This PR also changes most tests so they no longer depend on internal state of `Message`.

The outwards interfaces are unchanged.

I will leave this PR open to comments for 24 hours before merging (until 2015-07-13 15:00 Europe/Copenhagen).