### PR TITLE
Update to support new params in gcm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+**0.11.0**
+ * Added support for the [new parameters](https://developers.google.com/cloud-messaging/server-ref):
+   `priority`, `content_available`, `restricted_package_name`.
+ * If only a single registration id is passed to `Sender#send*`, it will be sent in the `to` field.
+   This is in accordance with the best practice of the current documentation, and allows users to send messages to notification keys.
+
 **0.10.0**
  * Deprecated `Message#addDataWithKeyValue` and `Message#addDataWithObject`:
    both of these now print a message to the log when used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Changelog
    `priority`, `content_available`, `restricted_package_name`.
  * If only a single registration id is passed to `Sender#send*`, it will be sent in the `to` field.
    This is in accordance with the best practice of the current documentation, and allows users to send messages to notification keys.
+ * It is no longer possible to change internal state of `Message`s by changing the variables directly.
+   For example, `message.collapseKey = "New Key"` is now illegal (won't work).
+   This is not considered a breaking change, because fiddling with internal state should not happen outside of the provided interface.
+   In this case, the correct way to set message variables is on construction of the `Message`.
 
 **0.10.0**
  * Deprecated `Message#addDataWithKeyValue` and `Message#addDataWithObject`:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ $ npm install node-gcm
 
 ## Requirements
 
-An Android device running 2.2 or newer and an API key as per [GCM getting started guide](http://developer.android.com/guide/google/gcm/gs.html).
+This library provides the server-side implementation of GCM.
+You need to generate an API key ([Sender ID](https://developers.google.com/cloud-messaging/gcm#senderid)).
+
+GCM notifications can be sent to both [Android](https://developers.google.com/cloud-messaging/android/start) and [iOS](https://developers.google.com/cloud-messaging/ios/start).
+If you are new to GCM you should probably look into the [documentation](https://developers.google.com/cloud-messaging/gcm).
 
 ## Example application
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ sender.send(message, registrationIds, 10, function (err, result) {
   else    console.log(result);
 });
 ```
+
 Notice that [you can *at most* send notifications to 1000 registration ids at a time](https://github.com/ToothlessGear/node-gcm/issues/42).
 This is due to [a restriction](http://developer.android.com/training/cloudsync/gcm.html) on the side of the GCM API.
-
 
 ## Notification usage
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ message.addData({
 	key2: 'message2'
 });
 
-// Change the message variables
-message.collapseKey = 'demo';
-message.delayWhileIdle = true;
-message.timeToLive = 3;
-message.dryRun = true;
-
 // Set up the sender with you API key
 var sender = new gcm.Sender('insert Google Server API Key here');
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,20 @@ var message = new gcm.Message();
 // ... or some given values
 var message = new gcm.Message({
 	collapseKey: 'demo',
+	priority: 3,
+	contentAvailable: true,
 	delayWhileIdle: true,
 	timeToLive: 3,
+	restrictedPackageName: "somePackageName",
+	dryRun: true,
 	data: {
 		key1: 'message1',
 		key2: 'message2'
+	},
+	notification: {
+		title: "Hello, World",
+		icon: "ic_launcher",
+		body: "This is a notification that will be displayed ASAP."
 	}
 });
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-gcm
 
-node-gcm is a Node.JS library for [**Google Cloud Messaging for Android**](http://developer.android.com/guide/google/gcm/index.html), which replaces Cloud 2 Device Messaging (C2DM).
+node-gcm is a Node.JS library for [**Google Cloud Messaging for Android**](https://developers.google.com/cloud-messaging/), which replaces Cloud 2 Device Messaging (C2DM).
 
 ## Installation
 

--- a/lib/message-options.js
+++ b/lib/message-options.js
@@ -17,8 +17,13 @@ module.exports = {
         __argName: "collapse_key",
         __argType: "string"
     },
-    //priority (number),
-    //content_available (boolean),
+    priority: {
+        __argType: "number"
+    },
+    contentAvailable: {
+        __argName: "content_available",
+        __argType: "boolean"
+    },
 	delayWhileIdle: {
         __argName: "delay_while_idle",
         __argType: "boolean"
@@ -27,7 +32,10 @@ module.exports = {
         __argName: "time_to_live",
         __argType: "number"
     },
-    //restricted_package_name (string),
+    restrictedPackageName: {
+        __argName: "restricted_package_name",
+        __argType: "string"
+    },
     dryRun: {
         __argName: "dry_run",
         __argType: "boolean"

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -30,12 +30,14 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
         callback = function() {};
     }
 
-    if(typeof registrationIds == "string") {
-        registrationIds = [registrationIds];
-    }
-
     var body = message.toJson();
-    body[Constants.JSON_REGISTRATION_IDS] = registrationIds;
+
+    if(typeof registrationIds == "string") {
+        body.to = registrationIds;
+    }
+    else {
+        body.registration_ids = registrationIds;
+    }
 
     var requestBody = JSON.stringify(body);
 

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -73,7 +73,7 @@ describe('UNIT Message', function () {
         notification: {}
       });
       expect(json.time_to_live).to.be.an("undefined");
-      expect(mess.dry_run).to.be.an("undefined");
+      expect(json.dry_run).to.be.an("undefined");
       expect(json.priority).to.be.an("undefined");
       expect(json.content_available).to.be.an("undefined");
       expect(json.restricted_package_name).to.be.an("undefined");

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -24,6 +24,9 @@ describe('UNIT Message', function () {
         delayWhileIdle: true,
         timeToLive: 100,
         dryRun: true,
+        priority: 4,
+        contentAvailable: false,
+        restrictedPackageName: "com.example.App",
         data: {
           score: 98
         },
@@ -38,6 +41,9 @@ describe('UNIT Message', function () {
         delay_while_idle: true,
         time_to_live: 100,
         dry_run: true,
+        priority: 4,
+        content_available: false,
+        restricted_package_name: "com.example.App",
         data: {
           score: 98
         },
@@ -68,6 +74,9 @@ describe('UNIT Message', function () {
       });
       expect(json.time_to_live).to.be.an("undefined");
       expect(mess.dry_run).to.be.an("undefined");
+      expect(json.priority).to.be.an("undefined");
+      expect(json.content_available).to.be.an("undefined");
+      expect(json.restricted_package_name).to.be.an("undefined");
     });
   });
 

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -107,6 +107,15 @@ describe('UNIT Sender', function () {
       var body = JSON.parse(args.options.body);
       expect(body.registration_ids).to.deep.equal(["registration id 1", "registration id 2"]);
     });
+    
+    it('should set the to field if a single reg (or other) id is passed in', function() {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, "registration id 1", function () {});
+      var body = JSON.parse(args.options.body);
+      expect(body.to).to.deep.equal("registration id 1");
+      expect(body.registration_ids).to.be.an("undefined");
+    })
 
     it('should pass an error into callback if request returns an error', function () {
       var callback = sinon.spy(),

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -103,9 +103,9 @@ describe('UNIT Sender', function () {
     it('should set the registration ids to reg ids passed in', function () {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
-      sender.sendNoRetry(m, 12, function () {});
+      sender.sendNoRetry(m, ["registration id 1", "registration id 2"], function () {});
       var body = JSON.parse(args.options.body);
-      expect(body[Constants.JSON_REGISTRATION_IDS]).to.equal(12);
+      expect(body[Constants.JSON_REGISTRATION_IDS]).to.deep.equal(["registration id 1", "registration id 2"]);
     });
 
     it('should pass an error into callback if request returns an error', function () {

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -105,7 +105,7 @@ describe('UNIT Sender', function () {
       var m = new Message({ data: {} });
       sender.sendNoRetry(m, ["registration id 1", "registration id 2"], function () {});
       var body = JSON.parse(args.options.body);
-      expect(body[Constants.JSON_REGISTRATION_IDS]).to.deep.equal(["registration id 1", "registration id 2"]);
+      expect(body.registration_ids).to.deep.equal(["registration id 1", "registration id 2"]);
     });
 
     it('should pass an error into callback if request returns an error', function () {


### PR DESCRIPTION
This PR adds support for the last few parameters that we did not yet support (fixes #136, fixes #101):

- priority
- content_available (we call it contentAvailable)
- restricted_package_name (we call it restrictedPackageName)

Additionally this PR changes the internal workings of Sender, so if only a single registration id is given, it will go into the `to` field. Fixes #107. Fixes #134.

This allows for use-cases such as Topic Messaging and Group Messaging (mentioned in #134).