### PR TITLE
Properly support priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var message = new gcm.Message();
 // ... or some given values
 var message = new gcm.Message({
 	collapseKey: 'demo',
-	priority: 3,
+	priority: 'high',
 	contentAvailable: true,
 	delayWhileIdle: true,
 	timeToLive: 3,

--- a/lib/message-options.js
+++ b/lib/message-options.js
@@ -18,7 +18,7 @@ module.exports = {
         __argType: "string"
     },
     priority: {
-        __argType: "number"
+        __argType: "string"
     },
     contentAvailable: {
         __argName: "content_available",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "Simen Bekkhus <sbekkhus91@gmail.com> (https://github.com/SimenB)",
     "Alexander Johansson <alex@dice.fm> (https://github.com/KATT)",
     "Ashwin R <ashrko619@gmail.com> (https://github.com/ashrko619)",
-    "Kaija Chang <kaija.chang@gmail.com> (https://github.com/kaija)"
+    "Kaija Chang <kaija.chang@gmail.com> (https://github.com/kaija)",
+    "Mo Kamioner <mkamioner@gmail.com> (https://github.com/mkamioner)"
   ],
   "repository": {
     "type": "git",

--- a/test/unit/messageSpec.js
+++ b/test/unit/messageSpec.js
@@ -24,7 +24,7 @@ describe('UNIT Message', function () {
         delayWhileIdle: true,
         timeToLive: 100,
         dryRun: true,
-        priority: 4,
+        priority: 'high',
         contentAvailable: false,
         restrictedPackageName: "com.example.App",
         data: {
@@ -41,7 +41,7 @@ describe('UNIT Message', function () {
         delay_while_idle: true,
         time_to_live: 100,
         dry_run: true,
-        priority: 4,
+        priority: 'high',
         content_available: false,
         restricted_package_name: "com.example.App",
         data: {


### PR DESCRIPTION
According to [GCM documentation](https://developers.google.com/cloud-messaging/concept-options#setting-the-priority-of-a-message), priority can be set using a string of `normal` or `high` instead of a number.

Fixes #147