### PR TITLE
fixing example timeToLive should be in milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var message = new gcm.Message({
 	priority: 'high',
 	contentAvailable: true,
 	delayWhileIdle: true,
-	timeToLive: 3,
+	timeToLive: 3000,
 	restrictedPackageName: "somePackageName",
 	dryRun: true,
 	data: {


### PR DESCRIPTION
updating README.md example timeToLive from seconds to milliseconds