### PR TITLE
Support explicit topic target in send()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ var regIds = ['YOUR_REG_ID_HERE'];
 // Set up the sender with you API key
 var sender = new gcm.Sender('YOUR_API_KEY_HERE');
 
-//Now the sender can be used to send messages
-sender.send(message, regIds, function (err, result) {
+// Now the sender can be used to send messages
+sender.send(message, { registrationIds: regIds }, function (err, result) {
 	if(err) console.error(err);
 	else 	console.log(result);
 });
 
-sender.sendNoRetry(message, regIds, function (err, result) {
+// Send to a topic, with no retry this time
+sender.sendNoRetry(message, { topic: '/topics/global' }, function (err, result) {
 	if(err) console.error(err);
 	else 	console.log(result);
 });
@@ -94,19 +95,19 @@ registrationIds.push('regId2');
 
 // Send the message
 // ... trying only once
-sender.sendNoRetry(message, registrationIds, function(err, result) {
+sender.sendNoRetry(message, { registrationIds: registrationIds }, function(err, result) {
   if(err) console.error(err);
   else    console.log(result);
 });
 
 // ... or retrying
-sender.send(message, registrationIds, function (err, result) {
+sender.send(message, { registrationIds: registrationIds }, function (err, result) {
   if(err) console.error(err);
   else    console.log(result);
 });
 
 // ... or retrying a specific number of times (10)
-sender.send(message, registrationIds, 10, function (err, result) {
+sender.send(message, { registrationIds: registrationIds }, 10, function (err, result) {
   if(err) console.error(err);
   else    console.log(result);
 });

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1,6 +1,7 @@
 var Constants = require('./constants');
 var req = require('request');
 var debug = require('debug')('node-gcm');
+var util = require('util');
 
 function Sender(key, options) {
     if (!(this instanceof Sender)) {
@@ -25,18 +26,55 @@ var parseAndRespond = function(resBody, callback) {
     callback(null, resBodyJSON);
 };
 
-Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
+function extractRecipient(recipient) {
+    var validKeys = ['registrationIds', 'topic', 'notificationKey'];
+    var theRecipient;
+
+    validKeys.forEach(function(key) {
+        if (recipient[key]) {
+            theRecipient = recipient[key];
+            return;
+        }
+    });
+
+    return {
+        err: theRecipient ?
+            null :
+            'Invalid recipient key(s) ' + Object.keys(recipient) + ' (valid keys: ' + validKeys.join(', ') + ')',
+        recipient: theRecipient
+    };
+}
+
+Sender.prototype.sendNoRetry = function(message, recipient, callback) {
     if(!callback) {
         callback = function() {};
     }
 
     var body = message.toJson();
 
-    if(typeof registrationIds == "string") {
-        body.to = registrationIds;
+    if(typeof recipient == "string") {
+        body.to = recipient;
+    }
+    else if (!util.isArray(recipient) && typeof recipient == "object") {
+        var o = extractRecipient(recipient);
+        var theRecipient;
+
+        if (o.err) {
+            return callback(o.err);
+        }
+        else {
+            theRecipient = o.recipient;
+        }
+
+        if (util.isArray(theRecipient)) {
+            body.registration_ids = theRecipient;
+        }
+        else {
+            body.to = theRecipient;
+        }
     }
     else {
-        body.registration_ids = registrationIds;
+        body.registration_ids = recipient;
     }
 
     var requestBody = JSON.stringify(body);
@@ -77,6 +115,7 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
             return callback('response is null', null);
 
         }
+
         if (res.statusCode >= 500) {
             debug('GCM service is unavailable (500)');
             return callback(res.statusCode, null);
@@ -92,8 +131,11 @@ Sender.prototype.sendNoRetry = function(message, registrationIds, callback) {
     });
 };
 
-Sender.prototype.send = function(message, registrationIds, options, callback) {
+Sender.prototype.send = function(message, recipient, options, callback) {
     var backoff, retries;
+
+    // In case of failure, will be passed to send() again for retry
+    var originalRecipient = recipient;
 
     if(typeof options == "object") {
         retries = options.retries;
@@ -120,16 +162,29 @@ Sender.prototype.send = function(message, registrationIds, options, callback) {
         callback = function() {};
     }
 
-    if(typeof registrationIds == "string") {
-        registrationIds = [registrationIds];
+    if(typeof recipient == "string") {
+        recipient = [recipient];
     }
-    if (!registrationIds.length) {
+    else if (!util.isArray(recipient) && typeof recipient == "object") {
+        // For topics, passing them to sendNoRetry() as if they were registration IDs
+        // will put them in the "to" value of the JSON payload, which what we want
+        var o = extractRecipient(recipient);
+
+        if (o.err) {
+            return callback(o.err);
+        }
+        else {
+            recipient = o.recipient;
+        }
+    }
+
+    if (util.isArray(recipient) && !recipient.length) {
         debug('No RegistrationIds given!');
         return process.nextTick(callback.bind(this, 'No RegistrationIds given!', null));
     }
 
     if(retries == 0) {
-        return this.sendNoRetry(message, registrationIds, callback);
+        return this.sendNoRetry(message, recipient, callback);
     }
     if (backoff > Constants.MAX_BACKOFF_DELAY) {
         backoff = Constants.MAX_BACKOFF_DELAY;
@@ -137,11 +192,11 @@ Sender.prototype.send = function(message, registrationIds, options, callback) {
 
     var self = this;
 
-    this.sendNoRetry(message, registrationIds, function(err, result) {
+    this.sendNoRetry(message, recipient, function(err, result) {
         // if we err'd resend them all
         if (err) {
             return setTimeout(function() {
-                self.send(message, registrationIds, {
+                self.send(message, originalRecipient, {
                     retries: retries - 1,
                     backoff: backoff * 2
                 }, callback);
@@ -150,10 +205,14 @@ Sender.prototype.send = function(message, registrationIds, options, callback) {
 
         // check for bad ids
         var unsentRegIds = [], regIdPositionMap = [];
-        for (var i = 0; i < registrationIds.length; i++) {
-            if (result.results[i].error === 'Unavailable') {
-                regIdPositionMap.push(i);
-                unsentRegIds.push(registrationIds[i]);
+
+        // Responses for messages sent a topic just contain { message_id: '...' } or { error: '...' }
+        if (result.results) {
+            for (var i = 0; i < recipient.length; i++) {
+                if (result.results[i].error === 'Unavailable') {
+                    regIdPositionMap.push(i);
+                    unsentRegIds.push(recipient[i]);
+                }
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "Alexander Johansson <alex@dice.fm> (https://github.com/KATT)",
     "Ashwin R <ashrko619@gmail.com> (https://github.com/ashrko619)",
     "Kaija Chang <kaija.chang@gmail.com> (https://github.com/kaija)",
-    "Mo Kamioner <mkamioner@gmail.com> (https://github.com/mkamioner)"
+    "Mo Kamioner <mkamioner@gmail.com> (https://github.com/mkamioner)",
+    "Bastien Léonard <bastien.leonard@gmail.com> (https://github.com/bastienleonard)"
   ],
   "repository": {
     "type": "git",

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -100,14 +100,23 @@ describe('UNIT Sender', function () {
       expect(body[Constants.PARAM_PAYLOAD_KEY]).to.deep.equal(mess.data);
     });
 
-    it('should set the registration ids to reg ids passed in', function () {
+    it('should set the registration ids to reg ids implicitly passed in', function () {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
       sender.sendNoRetry(m, ["registration id 1", "registration id 2"], function () {});
       var body = JSON.parse(args.options.body);
       expect(body.registration_ids).to.deep.equal(["registration id 1", "registration id 2"]);
     });
-    
+
+    it('should set the registration ids to reg ids explicitly passed in', function () {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      var regIds = ["registration id 1", "registration id 2"];
+      sender.sendNoRetry(m, { registrationIds: regIds }, function () {});
+      var body = JSON.parse(args.options.body);
+      expect(body.registration_ids).to.deep.equal(regIds);
+    });
+
     it('should set the to field if a single reg (or other) id is passed in', function() {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
@@ -116,6 +125,32 @@ describe('UNIT Sender', function () {
       expect(body.to).to.deep.equal("registration id 1");
       expect(body.registration_ids).to.be.an("undefined");
     })
+
+    it('should set the to field if a topic is passed in', function() {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      var topic = '/topics/tests';
+      sender.sendNoRetry(m, { topic: topic }, function () {});
+      var body = JSON.parse(args.options.body);
+      expect(body.to).to.deep.equal(topic);
+      expect(body.registration_ids).to.be.an("undefined");
+    })
+
+    it('should pass an error into callback if recipient is an empty object', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('string');
+    });
+
+    it('should pass an error into callback if recipient keys are invalid', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('string');
+    });
 
     it('should pass an error into callback if request returns an error', function () {
       var callback = sinon.spy(),
@@ -243,6 +278,24 @@ describe('UNIT Sender', function () {
       };
       var sender = new Sender('myKey');
       sender.send({}, [], 0, callback);
+    });
+
+    it('should pass an error into callback if recipient is an empty object', function (done) {
+      var callback = function(error) {
+        expect(error).to.be.a('string');
+        done();
+      };
+      var sender = new Sender('myKey');
+      sender.send({}, {}, 0, callback);
+    });
+
+    it('should pass an error into callback if recipient keys are invalid', function (done) {
+      var callback = function(error) {
+        expect(error).to.be.a('string');
+        done();
+      };
+      var sender = new Sender('myKey');
+      sender.send({}, { invalid: ['regId'] }, 0, callback);
     });
 
     it('should pass the message and the regId to sendNoRetry on call', function () {


### PR DESCRIPTION
Following issue #146:

This is a quick fix for sending to a topic with `send()`:

```javascript
sender.send(
    message,
    { topic: '/topics/global' }, // can also be { registrationIds: [...] },
    { retries: 2 },
    callback
);
```

If it looks good enough, I'll add support for the same parameters for `sendNoRetry()`.