### PR TITLE
Function expects Array not Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var regIds = ['YOUR_REG_ID_HERE'];
 var sender = new gcm.Sender('YOUR_API_KEY_HERE');
 
 // Now the sender can be used to send messages
-sender.send(message, { registrationIds: regIds }, function (err, result) {
+sender.send(message, regIds, function (err, result) {
 	if(err) console.error(err);
 	else 	console.log(result);
 });
@@ -95,19 +95,19 @@ registrationIds.push('regId2');
 
 // Send the message
 // ... trying only once
-sender.sendNoRetry(message, { registrationIds: registrationIds }, function(err, result) {
+sender.sendNoRetry(message, registrationIds, function(err, result) {
   if(err) console.error(err);
   else    console.log(result);
 });
 
 // ... or retrying
-sender.send(message, { registrationIds: registrationIds }, function (err, result) {
+sender.send(message, registrationIds, function (err, result) {
   if(err) console.error(err);
   else    console.log(result);
 });
 
 // ... or retrying a specific number of times (10)
-sender.send(message, { registrationIds: registrationIds }, 10, function (err, result) {
+sender.send(message, registrationIds, 10, function (err, result) {
   if(err) console.error(err);
   else    console.log(result);
 });


### PR DESCRIPTION
I believe this is what you guys intended, otherwise the Example Application spits `No RegistrationIds given!`.

sender.js:126
```js
  if (!registrationIds.length)
```
In Javascript Objects don't have lengths.