### PR TITLE
Update the hostname of the GCM endpoint

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,11 +6,11 @@
 
 var Constants = {
 
-    'GCM_SEND_ENDPOINT' : 'android.googleapis.com',
+    'GCM_SEND_ENDPOINT' : 'gcm-http.googleapis.com',
 
     'GCM_SEND_ENDPATH' : '/gcm/send',
 
-    'GCM_SEND_URI' : 'https://android.googleapis.com:443/gcm/send',
+    'GCM_SEND_URI' : 'https://gcm-http.googleapis.com:443/gcm/send',
 
     'ERROR_QUOTA_EXCEEDED' : 'QuotaExceeded',
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "Ashwin R <ashrko619@gmail.com> (https://github.com/ashrko619)",
     "Kaija Chang <kaija.chang@gmail.com> (https://github.com/kaija)",
     "Mo Kamioner <mkamioner@gmail.com> (https://github.com/mkamioner)",
-    "Bastien Léonard <bastien.leonard@gmail.com> (https://github.com/bastienleonard)"
+    "Bastien Léonard <bastien.leonard@gmail.com> (https://github.com/bastienleonard)",
+    "Elad Nava <eladnava@gmail.com> (https://github.com/eladnava)"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Google has modified the GCM documentation to use a new URL for its HTTP GCM endpoint: https://developers.google.com/cloud-messaging/http

* Closes #162