### PR TITLE
Update README.md with generalized project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-gcm
 
-node-gcm is a Node.JS library for [**Google Cloud Messaging for Android**](https://developers.google.com/cloud-messaging/), which replaces Cloud 2 Device Messaging (C2DM).
+node-gcm is a Node.JS library for [**Google Cloud Messaging**](https://developers.google.com/cloud-messaging/).
 
 ## Installation
 


### PR DESCRIPTION
Update the README.md, modifying the project description to exclude Android (as GCM now supports both Android and iOS devices), and remove the C2DM reference -- it's outdated.

Closes #166.