### PR TITLE
Add registrationTokens alias (as per new GCM terminology)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog
 **0.11.0**
  * Added support for the [new parameters](https://developers.google.com/cloud-messaging/server-ref):
    `priority`, `content_available`, `restricted_package_name`.
- * If only a single registration id is passed to `Sender#send*`, it will be sent in the `to` field.
+ * If only a single registration token is passed to `Sender#send*`, it will be sent in the `to` field.
    This is in accordance with the best practice of the current documentation, and allows users to send messages to notification keys.
  * It is no longer possible to change internal state of `Message`s by changing the variables directly.
    For example, `message.collapseKey = "New Key"` is now illegal (won't work).
@@ -31,7 +31,7 @@ Changelog
  * Updated *Contributing* section in README
  * Rewrote `Sender#send`, so it returns the correct result ordered as expected, even after retrying.
    The initial backoff time can now be specified, by passing an options object to the function.
- * Updated `Sender#send` and `Sender#sendNoRetry` to allow passing a single Registration ID without wrapping it in an array.
+ * Updated `Sender#send` and `Sender#sendNoRetry` to allow passing a single Registration Token without wrapping it in an array.
 
 **0.9.14**
  * `Message#addData` is now multi-purpose (works as either `Message#addDataWithObject` or `Message#addDataWithKeyValue`)
@@ -71,7 +71,7 @@ Changelog
 
 **0.9.9**
  * fix statusCode logging
- * Added a call of a callback function in case when no registration id were given
+ * Added a call of a callback function in case when no registration tokens were given
  * updated contributors
 
 **0.9.8**

--- a/examples/notification.js
+++ b/examples/notification.js
@@ -8,12 +8,12 @@ message.addNotification('icon', 'ic_launcher');
 message.addNotification('body', 'World');
 
 
-//Replace your mobile device registration Id here
-var regIds = ['ecG3ps_bNBk:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxXl7TDJkW'];
+//Add your mobile device registration tokens here
+var regTokens = ['ecG3ps_bNBk:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxXl7TDJkW'];
 //Replace your developer API key with GCM enabled here
 var sender = new gcm.Sender('AIza*******************5O6FM');
 
-sender.send(message, regIds, function (err, result) {
+sender.send(message, regTokens, function (err, result) {
     if(err) {
       console.error(err);
     } else {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -165,7 +165,7 @@ Sender.prototype.send = function(message, recipient, options, callback) {
         recipient = [recipient];
     }
     else if (!Array.isArray(recipient) && typeof recipient == "object") {
-        // For topics, passing them to sendNoRetry() as if they were registration IDs
+        // For topics, passing them to sendNoRetry() as if they were registration tokens
         // will put them in the "to" value of the JSON payload, which what we want
         var o = extractRecipient(recipient);
 
@@ -202,28 +202,28 @@ Sender.prototype.send = function(message, recipient, options, callback) {
             }, backoff);
         }
 
-        // check for bad ids
-        var unsentRegIds = [], regIdPositionMap = [];
+        // check for bad tokens
+        var unsentRegTokens = [], regTokenPositionMap = [];
 
         // Responses for messages sent a topic just contain { message_id: '...' } or { error: '...' }
         if (result.results) {
             for (var i = 0; i < recipient.length; i++) {
                 if (result.results[i].error === 'Unavailable') {
-                    regIdPositionMap.push(i);
-                    unsentRegIds.push(recipient[i]);
+                    regTokenPositionMap.push(i);
+                    unsentRegTokens.push(recipient[i]);
                 }
             }
         }
 
-        if (!unsentRegIds.length) {
+        if (!unsentRegTokens.length) {
             return callback(err, result);
         }
 
         debug("Results received but not all successful", result);
 
         setTimeout(function () {
-            debug("Retrying unsent registration ids");
-            self.send(message, unsentRegIds, {
+            debug("Retrying unsent registration tokens");
+            self.send(message, unsentRegTokens, {
                 retries: retries - 1,
                 backoff: backoff * 2
             }, function(err, retriedResult) {
@@ -235,14 +235,14 @@ Sender.prototype.send = function(message, recipient, options, callback) {
                 //Map retried results onto their previous positions in the full array
                 var retriedResults = retriedResult.results;
                 for(var i = 0; i < result.results.length; i++) {
-                    var oldIndex = regIdPositionMap[i];
+                    var oldIndex = regTokenPositionMap[i];
                     result.results[oldIndex] = retriedResults[i];
                 }
 
                 //Update the fields on the result depending on newly returned value
                 result.success += retriedResult.success;
                 result.canonical_ids += retriedResult.canonical_ids;
-                result.failure -= unsentRegIds.length - retriedResult.failure;
+                result.failure -= unsentRegTokens.length - retriedResult.failure;
 
                 callback(null, result);
             });

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -26,7 +26,7 @@ var parseAndRespond = function(resBody, callback) {
 };
 
 function extractRecipient(recipient) {
-    var validKeys = ['registrationIds', 'topic', 'notificationKey'];
+    var validKeys = ['registrationIds', 'registrationTokens', 'topic', 'notificationKey'];
     var theRecipient;
 
     validKeys.forEach(function(key) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -178,8 +178,8 @@ Sender.prototype.send = function(message, recipient, options, callback) {
     }
 
     if (Array.isArray(recipient) && !recipient.length) {
-        debug('No RegistrationIds given!');
-        return process.nextTick(callback.bind(this, 'No RegistrationIds given!', null));
+        debug('No recipient provided!');
+        return process.nextTick(callback.bind(this, 'No recipient provided!', null));
     }
 
     if(retries == 0) {

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -112,7 +112,7 @@ describe('UNIT Sender', function () {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
       var regIds = ["registration id 1", "registration id 2"];
-      sender.sendNoRetry(m, { registrationIds: regIds }, function () {});
+      sender.sendNoRetry(m, { registrationTokens: regIds }, function () {});
       var body = JSON.parse(args.options.body);
       expect(body.registration_ids).to.deep.equal(regIds);
     });

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -112,9 +112,18 @@ describe('UNIT Sender', function () {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
       var regIds = ["registration id 1", "registration id 2"];
-      sender.sendNoRetry(m, { registrationTokens: regIds }, function () {});
+      sender.sendNoRetry(m, { registrationIds: regIds }, function () {});
       var body = JSON.parse(args.options.body);
       expect(body.registration_ids).to.deep.equal(regIds);
+    });
+
+    it('should set the registration ids to reg tokens explicitly passed in', function () {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      var regTokens = ["registration id 1", "registration id 2"];
+      sender.sendNoRetry(m, { registrationTokens: regTokens }, function () {});
+      var body = JSON.parse(args.options.body);
+      expect(body.registration_ids).to.deep.equal(regTokens);
     });
 
     it('should set the to field if a single reg (or other) id is passed in', function() {

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -100,38 +100,38 @@ describe('UNIT Sender', function () {
       expect(body[Constants.PARAM_PAYLOAD_KEY]).to.deep.equal(mess.data);
     });
 
-    it('should set the registration ids to reg ids implicitly passed in', function () {
+    it('should set the registration_ids to reg tokens implicitly passed in', function () {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
-      sender.sendNoRetry(m, ["registration id 1", "registration id 2"], function () {});
+      sender.sendNoRetry(m, ["registration token 1", "registration token 2"], function () {});
       var body = JSON.parse(args.options.body);
-      expect(body.registration_ids).to.deep.equal(["registration id 1", "registration id 2"]);
+      expect(body.registration_ids).to.deep.equal(["registration token 1", "registration token 2"]);
     });
 
-    it('should set the registration ids to reg ids explicitly passed in', function () {
+    it('should set the registration_ids to reg tokens explicitly passed in', function () {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
-      var regIds = ["registration id 1", "registration id 2"];
-      sender.sendNoRetry(m, { registrationIds: regIds }, function () {});
+      var regTokens = ["registration token 1", "registration token 2"];
+      sender.sendNoRetry(m, { registrationIds: regTokens }, function () {});
       var body = JSON.parse(args.options.body);
-      expect(body.registration_ids).to.deep.equal(regIds);
+      expect(body.registration_ids).to.deep.equal(regTokens);
     });
 
-    it('should set the registration ids to reg tokens explicitly passed in', function () {
+    it('should set the registration_ids to reg tokens explicitly passed in', function () {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
-      var regTokens = ["registration id 1", "registration id 2"];
+      var regTokens = ["registration token 1", "registration token 2"];
       sender.sendNoRetry(m, { registrationTokens: regTokens }, function () {});
       var body = JSON.parse(args.options.body);
       expect(body.registration_ids).to.deep.equal(regTokens);
     });
 
-    it('should set the to field if a single reg (or other) id is passed in', function() {
+    it('should set the to field if a single reg (or other) token is passed in', function() {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });
-      sender.sendNoRetry(m, "registration id 1", function () {});
+      sender.sendNoRetry(m, "registration token 1", function () {});
       var body = JSON.parse(args.options.body);
-      expect(body.to).to.deep.equal("registration id 1");
+      expect(body.to).to.deep.equal("registration token 1");
       expect(body.registration_ids).to.be.an("undefined");
     })
 
@@ -250,10 +250,10 @@ describe('UNIT Sender', function () {
 
     before( function () {
       restore.sendNoRetry = Sender.prototype.sendNoRetry;
-      Sender.prototype.sendNoRetry = function (message, reg_ids, callback) {
+      Sender.prototype.sendNoRetry = function (message, reg_tokens, callback) {
         console.log('Firing send');
         args.message = message;
-        args.reg_ids = reg_ids;
+        args.reg_tokens = reg_tokens;
         args.tries++;
         var nextResult;
         if(!args.result) {
@@ -278,9 +278,9 @@ describe('UNIT Sender', function () {
       Sender.prototype.sendNoRetry = restore.sendNoRetry;
     });
 
-    it.skip('should do something if passed not an array for regIds');
+    it.skip('should do something if passed not an array for regTokens');
 
-    it('should pass an error into callback if array has no regIds', function (done) {
+    it('should pass an error into callback if array has no regTokens', function (done) {
       var callback = function(error) {
         expect(error).to.be.a('string');
         done();
@@ -304,32 +304,32 @@ describe('UNIT Sender', function () {
         done();
       };
       var sender = new Sender('myKey');
-      sender.send({}, { invalid: ['regId'] }, 0, callback);
+      sender.send({}, { invalid: ['regToken'] }, 0, callback);
     });
 
-    it('should pass the message and the regId to sendNoRetry on call', function () {
+    it('should pass the message and the regToken to sendNoRetry on call', function () {
       var sender = new Sender('myKey'),
           message = { data: {} },
-          regId = [24];
+          regToken = [24];
       setArgs(null, {});
-      sender.send(message, regId, 0, function () {});
+      sender.send(message, regToken, 0, function () {});
       expect(args.message).to.equal(message);
-      expect(args.reg_ids).to.equal(regId);
+      expect(args.reg_tokens).to.equal(regToken);
       expect(args.tries).to.equal(1);
     });
 
-    it('should pass the message and the regIds to sendNoRetry on call', function () {
+    it('should pass the message and the regTokens to sendNoRetry on call', function () {
       var sender = new Sender('myKey'),
           message = { data: {} },
-          regIds = [24, 34, 44];
+          regTokens = [24, 34, 44];
       setArgs(null, {});
-      sender.send(message, regIds, 0, function () {});
+      sender.send(message, regTokens, 0, function () {});
       expect(args.message).to.equal(message);
-      expect(args.reg_ids).to.equal(regIds);
+      expect(args.reg_tokens).to.equal(regTokens);
       expect(args.tries).to.equal(1);
     });
 
-    it('should pass the result into callback if successful for id', function () {
+    it('should pass the result into callback if successful for token', function () {
       var callback = sinon.spy(),
           result = { success: true },
           sender = new Sender('myKey');
@@ -340,7 +340,7 @@ describe('UNIT Sender', function () {
       expect(args.tries).to.equal(1);
     });
 
-    it('should pass the result into callback if successful for ids', function () {
+    it('should pass the result into callback if successful for tokens', function () {
       var callback = sinon.spy(),
           result = { success: true },
           sender = new Sender('myKey');
@@ -351,7 +351,7 @@ describe('UNIT Sender', function () {
       expect(args.tries).to.equal(1);
     });
 
-    it('should pass the error into callback if failure and no retry for id', function () {
+    it('should pass the error into callback if failure and no retry for token', function () {
       var callback = sinon.spy(),
           error = 'my error',
           sender = new Sender('myKey');
@@ -362,7 +362,7 @@ describe('UNIT Sender', function () {
       expect(args.tries).to.equal(1);
     });
 
-    it('should pass the error into callback if failure and no retry for ids', function () {
+    it('should pass the error into callback if failure and no retry for tokens', function () {
       var callback = sinon.spy(),
           error = 'my error',
           sender = new Sender('myKey');
@@ -385,12 +385,12 @@ describe('UNIT Sender', function () {
       sender.send({ data: {}}, [1], 1, callback);
     });
 
-    it('should retry if not all regIds were successfully sent', function (done) {
+    it('should retry if not all regTokens were successfully sent', function (done) {
       var callback = function () {
         expect(args.tries).to.equal(3);
-        // Last call of sendNoRetry should be for only failed regIds
-        expect(args.reg_ids.length).to.equal(1);
-        expect(args.reg_ids[0]).to.equal(3);
+        // Last call of sendNoRetry should be for only failed regTokens
+        expect(args.reg_tokens.length).to.equal(1);
+        expect(args.reg_tokens[0]).to.equal(3);
         done();
       };
       var sender = new Sender('myKey');
@@ -401,11 +401,11 @@ describe('UNIT Sender', function () {
       }, callback);
     });
 
-    it('should retry all regIds in event of an error', function (done) {
+    it('should retry all regTokens in event of an error', function (done) {
       var start = new Date();
       var callback = function () {
         expect(args.tries).to.equal(2);
-        expect(args.reg_ids.length).to.equal(3);
+        expect(args.reg_tokens.length).to.equal(3);
         done();
       };
       var sender = new Sender('myKey');


### PR DESCRIPTION
Create an alias for `registrationTokens` as per the new GCM terminology "registration tokens" instead of "registration IDs". 

```
// Now the sender can be used to send messages
sender.send(message, { registrationTokens: regTokens }, function (err, result) {
    if(err) console.error(err);
    else    console.log(result);
});
```
It behaves the same as `registrationIds`. We decided to leave `registrationIds` intact to maintain backward compatibility.

Also, update the "no recipient" error message, as recipients can be both tokens and topics now.

```
 if (Array.isArray(recipient) && !recipient.length) {
        debug('No recipient provided!');
        return process.nextTick(callback.bind(this, 'No recipient provided!', null));
    }
```
Finally, incorporate the new alias in the senderSpec.js test.

References #160.