### PR TITLE
Rename send/sendNoRetry callback param to "response"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ var regTokens = ['YOUR_REG_TOKEN_HERE'];
 var sender = new gcm.Sender('YOUR_API_KEY_HERE');
 
 // Now the sender can be used to send messages
-sender.send(message, { registrationTokens: regTokens }, function (err, result) {
+sender.send(message, { registrationTokens: regTokens }, function (err, response) {
 	if(err) console.error(err);
-	else 	console.log(result);
+	else 	console.log(response);
 });
 
 // Send to a topic, with no retry this time
-sender.sendNoRetry(message, { topic: '/topics/global' }, function (err, result) {
+sender.sendNoRetry(message, { topic: '/topics/global' }, function (err, response) {
 	if(err) console.error(err);
-	else 	console.log(result);
+	else 	console.log(response);
 });
 ```
 
@@ -95,21 +95,21 @@ registrationTokens.push('regToken2');
 
 // Send the message
 // ... trying only once
-sender.sendNoRetry(message, { registrationTokens: registrationTokens }, function(err, result) {
+sender.sendNoRetry(message, { registrationTokens: registrationTokens }, function(err, response) {
   if(err) console.error(err);
-  else    console.log(result);
+  else    console.log(response);
 });
 
 // ... or retrying
-sender.send(message, { registrationTokens: registrationTokens }, function (err, result) {
+sender.send(message, { registrationTokens: registrationTokens }, function (err, response) {
   if(err) console.error(err);
-  else    console.log(result);
+  else    console.log(response);
 });
 
 // ... or retrying a specific number of times (10)
-sender.send(message, { registrationTokens: registrationTokens }, 10, function (err, result) {
+sender.send(message, { registrationTokens: registrationTokens }, 10, function (err, response) {
   if(err) console.error(err);
-  else    console.log(result);
+  else    console.log(response);
 });
 ```
 

--- a/examples/notification.js
+++ b/examples/notification.js
@@ -13,10 +13,10 @@ var regTokens = ['ecG3ps_bNBk:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 //Replace your developer API key with GCM enabled here
 var sender = new gcm.Sender('AIza*******************5O6FM');
 
-sender.send(message, regTokens, function (err, result) {
+sender.send(message, regTokens, function (err, response) {
     if(err) {
       console.error(err);
     } else {
-      console.log(result);
+      console.log(response);
     }
 });

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -195,7 +195,7 @@ Sender.prototype.send = function(message, recipient, options, callback) {
 
     var self = this;
 
-    this.sendNoRetry(message, recipient, function(err, result) {
+    this.sendNoRetry(message, recipient, function(err, response) {
         // if we err'd resend them all
         if (err) {
             return setTimeout(function() {
@@ -210,9 +210,9 @@ Sender.prototype.send = function(message, recipient, options, callback) {
         var unsentRegTokens = [], regTokenPositionMap = [];
 
         // Responses for messages sent a topic just contain { message_id: '...' } or { error: '...' }
-        if (result.results) {
+        if (response.results) {
             for (var i = 0; i < recipient.length; i++) {
-                if (result.results[i].error === 'Unavailable') {
+                if (response.results[i].error === 'Unavailable') {
                     regTokenPositionMap.push(i);
                     unsentRegTokens.push(recipient[i]);
                 }
@@ -220,35 +220,35 @@ Sender.prototype.send = function(message, recipient, options, callback) {
         }
 
         if (!unsentRegTokens.length) {
-            return callback(err, result);
+            return callback(err, response);
         }
 
-        debug("Results received but not all successful", result);
+        debug("Response received but not all successful", response);
 
         setTimeout(function () {
             debug("Retrying unsent registration tokens");
             self.send(message, unsentRegTokens, {
                 retries: retries - 1,
                 backoff: backoff * 2
-            }, function(err, retriedResult) {
+            }, function(err, retriedResponse) {
                 //If the recursive call err'd completely, our current result is the best available
                 if(err) {
-                    return callback(null, result);
+                    return callback(null, response);
                 }
 
                 //Map retried results onto their previous positions in the full array
-                var retriedResults = retriedResult.results;
-                for(var i = 0; i < result.results.length; i++) {
+                var retriedResults = retriedResponse.results;
+                for(var i = 0; i < response.results.length; i++) {
                     var oldIndex = regTokenPositionMap[i];
-                    result.results[oldIndex] = retriedResults[i];
+                    response.results[oldIndex] = retriedResults[i];
                 }
 
                 //Update the fields on the result depending on newly returned value
-                result.success += retriedResult.success;
-                result.canonical_ids += retriedResult.canonical_ids;
-                result.failure -= unsentRegTokens.length - retriedResult.failure;
+                response.success += retriedResponse.success;
+                response.canonical_ids += retriedResponse.canonical_ids;
+                response.failure -= unsentRegTokens.length - retriedResponse.failure;
 
-                callback(null, result);
+                callback(null, response);
             });
         }, backoff);
     });

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -267,10 +267,10 @@ describe('UNIT Sender', function () {
     var restore = {},
         backoff = Constants.BACKOFF_INITIAL_DELAY;
     // Set args passed into sendNoRetry
-    function setArgs(err, result) {
+    function setArgs(err, response) {
       args = {
         err: err,
-        result: result,
+        response: response,
         tries: 0
       };
     };
@@ -282,22 +282,22 @@ describe('UNIT Sender', function () {
         args.message = message;
         args.reg_tokens = reg_tokens;
         args.tries++;
-        var nextResult;
-        if(!args.result) {
-          nextResult = args.result;
+        var nextResponse;
+        if(!args.response) {
+          nextResponse = args.response;
         }
-        else if(args.result.length > 1) {
-          nextResult = args.result.slice(0,1)[0];
-          args.result = args.result.slice(1,args.result.length);
+        else if(args.response.length > 1) {
+          nextResponse = args.response.slice(0,1)[0];
+          args.response = args.response.slice(1,args.response.length);
         }
-        else if(args.result.length == 1) {
-          args.result = args.result[0];
-          nextResult = args.result;
+        else if(args.response.length == 1) {
+          args.response = args.response[0];
+          nextResponse = args.response;
         }
         else {
-          nextResult = args.result;
+          nextResponse = args.response;
         }
-        callback( args.err, nextResult );
+        callback( args.err, nextResponse );
       };
     });
 
@@ -356,25 +356,25 @@ describe('UNIT Sender', function () {
       expect(args.tries).to.equal(1);
     });
 
-    it('should pass the result into callback if successful for token', function () {
+    it('should pass the response into callback if successful for token', function () {
       var callback = sinon.spy(),
-          result = { success: true },
+          response = { success: true },
           sender = new Sender('myKey');
-      setArgs(null, result);
+      setArgs(null, response);
       sender.send({}, [1], 0, callback);
       expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][1]).to.equal(result);
+      expect(callback.args[0][1]).to.equal(response);
       expect(args.tries).to.equal(1);
     });
 
-    it('should pass the result into callback if successful for tokens', function () {
+    it('should pass the response into callback if successful for tokens', function () {
       var callback = sinon.spy(),
-          result = { success: true },
+          response = { success: true },
           sender = new Sender('myKey');
-      setArgs(null, result);
+      setArgs(null, response);
       sender.send({}, [1, 2, 3], 0, callback);
       expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][1]).to.equal(result);
+      expect(callback.args[0][1]).to.equal(response);
       expect(args.tries).to.equal(1);
     });
 
@@ -441,11 +441,11 @@ describe('UNIT Sender', function () {
     });
 
     it('should update the failures and successes correctly when retrying', function (done) {
-      var callback = function(error, result) {
+      var callback = function(error, response) {
         expect(error).to.equal(null);
-        expect(result.canonical_ids).to.equal(1);
-        expect(result.success).to.equal(2);
-        expect(result.failure).to.equal(0);
+        expect(response.canonical_ids).to.equal(1);
+        expect(response.success).to.equal(2);
+        expect(response.failure).to.equal(0);
         done();
       };
       var sender = new Sender('myKey');
@@ -457,11 +457,11 @@ describe('UNIT Sender', function () {
     });
 
     it('should update the failures and successes correctly when retrying and failing some', function (done) {
-      var callback = function(error, result) {
+      var callback = function(error, response) {
         expect(error).to.equal(null);
-        expect(result.canonical_ids).to.equal(0);
-        expect(result.success).to.equal(1);
-        expect(result.failure).to.equal(2);
+        expect(response.canonical_ids).to.equal(0);
+        expect(response.success).to.equal(1);
+        expect(response.failure).to.equal(2);
         done();
       };
       var sender = new Sender('myKey');


### PR DESCRIPTION
As per the outcome of #104, we decided to rename the `result` parameter
to `response` in all sender.send() and sender.sendNoRetry() calls.

Files renamed:
* README.md usages of sender.send/sendNoRetry
* examples/notification.js usage of sender.send
* senderSpec.js tests utilizing sender.send/sendNoRetry
* lib/sender.js references to the old parameter in both
sender.sendNoRetry and in other declarations

Ran `npm test` and success returned.