### PR TITLE
Allow setting all request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,29 @@ message.addNotification({
 
 Notice notification payload defined in [GCM Connection Server Reference](https://developers.google.com/cloud-messaging/server-ref#table1)
 
+## Custom GCM request options
+
+You can provide custom `request` options such as `proxy` and `timeout` for the GCM request. For more information, refer to [the complete list of request options](https://github.com/request/request#requestoptions-callback). Note that the following options cannot be overriden: `method`, `uri`, `body`, as well as the following headers: `Authorization`, `Content-Type`, and `Content-Length`.
+
+```js
+// Set custom request options
+var requestOptions = {
+	proxy: 'http://127.0.0.1:8888',
+	timeout: 5000
+};
+
+// Set up the sender with your API key and request options
+var sender = new gcm.Sender('YOUR_API_KEY_HERE', requestOptions);
+
+// Prepare a GCM message...
+
+// Send it to GCM endpoint with modified request options
+sender.send(message, { registrationTokens: regTokens }, function (err, response) {
+    if(err) console.error(err);
+    else     console.log(response);
+});
+```
+
 ## Debug
 
 To enable debug mode (print requests and responses to and from GCM),

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1,4 +1,5 @@
 var Constants = require('./constants');
+var _ = require('lodash');
 var req = require('request');
 var debug = require('debug')('node-gcm');
 
@@ -88,28 +89,19 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
         uri: Constants.GCM_SEND_URI,
         body: requestBody
     };
-
-    if (this.options && this.options.proxy) {
-        post_options.proxy = this.options.proxy;
-    }
-
-    if (this.options && this.options.maxSockets) {
-        post_options.maxSockets = this.options.maxSockets;
-    }
-
-    var timeout = Constants.SOCKET_TIMEOUT;
-
-    if (this.options && this.options.timeout) {
-        timeout =  this.options.timeout;
-    }
-
-    post_options.timeout = timeout;
     
-    if (this.options && typeof(this.options.strictSsl) == "boolean") {
-        post_options.strictSSL = this.options.strictSsl;
+    // Get externally-provided request options passed to gcm.Sender() constructor
+    var sender_options = this.options ? this.options : {};
+    
+    // Set request options to default to externally-provided options, and override with our own post_options
+    var request_options = _.defaults(post_options, sender_options);
+    
+    // Allow overriding timeout externally, set to default SOCKET_TIMEOUT if not provided
+    if ( ! request_options.timeout ) {
+        request_options.timeout = Constants.SOCKET_TIMEOUT;
     }
 
-    var post_req = req(post_options, function (err, res, resBody) {
+    var post_req = req(request_options, function (err, res, resBody) {
         if (err) {
             return callback(err, null);
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -91,7 +91,7 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
     };
     
     // Get externally-provided request options passed to gcm.Sender() constructor
-    var sender_options = this.options ? this.options : {};
+    var sender_options = this.options || {};
     
     // Set request options to default to externally-provided options, and override with our own post_options (allow setting new headers)
     var request_options = _.defaultsDeep(post_options, sender_options);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -93,8 +93,8 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
     // Get externally-provided request options passed to gcm.Sender() constructor
     var sender_options = this.options ? this.options : {};
     
-    // Set request options to default to externally-provided options, and override with our own post_options
-    var request_options = _.defaults(post_options, sender_options);
+    // Set request options to default to externally-provided options, and override with our own post_options (allow setting new headers)
+    var request_options = _.defaultsDeep(post_options, sender_options);
     
     // Allow overriding timeout externally, set to default SOCKET_TIMEOUT if not provided
     if ( ! request_options.timeout ) {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,9 @@
     "test": "mocha test/**/*Spec.js"
   },
   "dependencies": {
-    "request": "^2.27.0",
-    "debug": "^0.8.1"
+    "debug": "^0.8.1",
+    "lodash": "^3.10.1",
+    "request": "^2.27.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -67,6 +67,48 @@ describe('UNIT Sender', function () {
       expect(args.options.timeout).to.equal(options.timeout);
       expect(args.options.strictSSL).to.equal(options.strictSSL);
     });
+
+    it('should not override internal request params if passed into constructor (except timeout)', function () {
+      var options = {
+        method: 'GET',
+        headers: {
+            Authorization: 'test'
+        },
+        uri: 'http://example.com',
+        body: 'test'
+      };
+      var sender = new Sender('mykey', options);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', function () {});
+      expect(args.options.method).to.not.equal(options.method);
+      expect(args.options.headers).to.not.deep.equal(options.headers);
+      expect(args.options.uri).to.not.equal(options.uri);
+      expect(args.options.body).to.not.equal(options.body);
+    });
+
+    it('should not override internal request headers if passed into constructor', function () {
+      var options = {
+        headers: {
+            Authorization: 'test'
+        }
+      };
+      var sender = new Sender('mykey', options);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', function () {});
+      expect(args.options.headers.Authorization).to.not.equal(options.headers.Auhtorization);
+    });
+
+    it('should allow extending request headers if passed into constructor', function () {
+      var options = {
+        headers: {
+            Custom: true
+        }
+      };
+      var sender = new Sender('mykey', options);
+      var m = new Message({ data: {} });
+      sender.sendNoRetry(m, '', function () {});
+      expect(args.options.headers.Custom).to.deep.equal(options.headers.Custom);
+    });
     
     if('should not set strictSSL of req object if not passed into constructor', function () {
       var options = {

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -52,12 +52,12 @@ describe('UNIT Sender', function () {
       };
     };
 
-    it('should set proxy, maxSockets, timeout and/or strictSsl of req object if passed into constructor', function () {
+    it('should set proxy, maxSockets, timeout and/or strictSSL of req object if passed into constructor', function () {
       var options = {
         proxy: 'http://myproxy.com',
         maxSockets: 100,
         timeout: 1000,
-        strictSsl: false
+        strictSSL: false
       };
       var sender = new Sender('mykey', options);
       var m = new Message({ data: {} });
@@ -65,10 +65,10 @@ describe('UNIT Sender', function () {
       expect(args.options.proxy).to.equal(options.proxy);
       expect(args.options.maxSockets).to.equal(options.maxSockets);
       expect(args.options.timeout).to.equal(options.timeout);
-      expect(args.options.strictSSL).to.equal(options.strictSsl);
+      expect(args.options.strictSSL).to.equal(options.strictSSL);
     });
     
-    if('should not set strictSsl of req object if not passed into constructor', function () {
+    if('should not set strictSSL of req object if not passed into constructor', function () {
       var options = {
         proxy: 'http://myproxy.com',
         maxSockets: 100,
@@ -80,12 +80,12 @@ describe('UNIT Sender', function () {
       expect(args.options.strictSSL).to.be.an('undefined');
     });
 
-  if('should not set strictSsl of req object if the one passed into constructor is not a boolean', function () {
+  if('should not set strictSSL of req object if the one passed into constructor is not a boolean', function () {
       var options = {
         proxy: 'http://myproxy.com',
         maxSockets: 100,
         timeout: 1000,
-        strictSsl: "hi"
+        strictSSL: "hi"
       };
       var sender = new Sender('mykey', options);
       var m = new Message({ data: {} });


### PR DESCRIPTION
As discussed in #179, we'd like developers to be able to set all request options externally, by providing an object to the `gcm.Sender()` constructor, such as the request proxy, timeout, strictSSL, etc.

Changes:
* Require `lodash`
* Removed manual checks for `proxy`, `maxSockets`, `timeout`, and
`strictSSL` request options
* Added a variable `sender_options` that contains the request options passed to gcm.Sender()
* Added a variable `request_options` which uses Lodash's `_.defaults()` function to prevent overriding our internal options with
externally-provided ones
* Allow overriding `timeout` externally if provided, if not, use `Constants.SOCKET_TIMEOUT` (same as old behavior)
* Modified `post_req` to use the `request_options` instead of the old `post_options` which was manually constructed

Checked and works. Ran `npm test` successfully. External options do not override (except `timeout` and new `headers`)

Closes #179.