### PR TITLE
Fix request proxy bug due to "Content-Length" header

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -12,20 +12,6 @@ function Sender(key, options) {
     this.options = options;
 }
 
-var parseAndRespond = function(resBody, callback) {
-    var resBodyJSON;
-
-    try {
-        resBodyJSON = JSON.parse(resBody);
-    } catch (e) {
-        debug("Error parsing GCM response " + e);
-        callback("Error parsing GCM response");
-        return;
-    }
-
-    callback(null, resBodyJSON);
-};
-
 function extractRecipient(recipient) {
     var validKeys = ['registrationIds', 'registrationTokens', 'topic', 'notificationKey'];
     var theRecipient;
@@ -77,17 +63,13 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
         body.registration_ids = recipient;
     }
 
-    var requestBody = JSON.stringify(body);
-
     var post_options = {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json',
-            'Content-length': Buffer.byteLength(requestBody, 'utf8'),
             'Authorization': 'key=' + this.key
         },
         uri: Constants.GCM_SEND_URI,
-        body: requestBody
+        json: body
     };
     
     // Get externally-provided request options passed to gcm.Sender() constructor
@@ -101,7 +83,7 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
         request_options.timeout = Constants.SOCKET_TIMEOUT;
     }
 
-    var post_req = req(request_options, function (err, res, resBody) {
+    var post_req = req(request_options, function (err, res, resBodyJSON) {
         if (err) {
             return callback(err, null);
 
@@ -118,11 +100,11 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
             debug('Unauthorized (401). Check that your API token is correct.');
             return callback(res.statusCode, null);
         } else if (res.statusCode !== 200) {
-            debug('Invalid request (' + res.statusCode + '): ' + resBody);
+            debug('Invalid request (' + res.statusCode + '): ' + resBodyJSON);
             return callback(res.statusCode, null);
         }
 
-        parseAndRespond(resBody, callback);
+        callback(null, resBodyJSON);
     });
 };
 


### PR DESCRIPTION
This PR closes #97, an issue regarding specifying a custom `proxy` for node-gcm requests.

Due to a bug with the `request` module (explained in #97), the initial `HTTP CONNECT` request never
succeeds.

This commit works around the issue by:
1. Removing hard-coded declarations of `Content-Type` and `Content-Length` headers (`request` will add them automatically if we supply `json` payload)
2. Supply the request body in the `json` parameter (as an object - not as a JSON-stringified string)
3. Remove the `parseAndRespond` function which is no longer needed, as `request` returns a JSON object (it parses it for us)

Also, lots of tests relied on the way things worked before, with the `body` parameter, the custom content headers, and our own response JSON parsing. Updated them all, and they all pass.

1. Changed `body` lookups to `json` (in request options)
2. No need to `JSON.parse()` the request body anymore
3. Bad JSON error will be thrown by request module