### PR TITLE
Improved error handling in extractRecipient() and improved recipient documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ sender.send(message, { registrationTokens: registrationTokens }, 10, function (e
   else    console.log(response);
 });
 ```
+## Recipients
+
+You can send push notifications to various recipient types by providing one of the following recipient keys:
+
+
+|Key|Type|Description|
+|---|---|---|
+|topic|String|A [GCM PubSub](https://developers.google.com/cloud-messaging/topic-messaging) topic.
+|notificationKey|String|Deprecated. A key that groups multiple registration tokens linked to the same user.
+|registrationIds|String[]|Deprecated. Use registrationTokens instead.|
+|registrationTokens|String[]|A list of registration tokens. Must contain at least 1 and at most 1000 registration tokens.|
+
+If you provide an incorrect recipient key or object type, an `Error` object will be returned to your callback.
 
 Notice that [you can *at most* send notifications to 1000 registration tokens at a time](https://github.com/ToothlessGear/node-gcm/issues/42).
 This is due to [a restriction](http://developer.android.com/training/cloudsync/gcm.html) on the side of the GCM API.

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,36 +27,49 @@ var parseAndRespond = function(resBody, callback) {
 };
 
 function extractRecipient(recipient) {
-    var validStringKeys = ['topic', 'notificationKey'];
-    var validArrayKeys = ['registrationIds', 'registrationTokens'];
-    var theRecipient, err;
-
-    validArrayKeys.forEach(function(key) {
-        if (recipient[key]) {
-            if (!Array.isArray(recipient[key])) {
-                err = new Error("Recipient key '" + key + "' should be provided as an array.");
-            }
-            theRecipient = recipient[key];
-            return;
-        }
-    });
+    // Group the possible recipient keys by their object type
+    var validRecipientKeys = {
+        String: [
+            'topic',
+            'notificationKey'
+        ],
+        Array: [
+            'registrationIds',
+            'registrationTokens'
+        ]
+    };
     
-    validStringKeys.forEach(function(key) {
-        if (recipient[key]) {
-            if ( typeof recipient[key] != "string" ) {
-                err = new Error("Recipient key '" + key + "' should be provided as a string.");
+    var theRecipient;
+    
+    for (var type in validRecipientKeys) {
+        for (var i in validRecipientKeys[type]) {
+            var key = validRecipientKeys[type][i];
+            
+            if (recipient[key]) {
+                // Type validation
+                if ((type == 'String' && typeof recipient[key] != "string") 
+                    || (type == 'Array' && !Array.isArray(recipient[key]))) {
+                    return { err: new Error("Recipient key '" + key + "' should be provided as '" + type + "'.") };
+                }
+                
+                // Avoid multiple recipient keys
+                if (theRecipient) {
+                    return { err: new Error("Please specify only one recipient key at a time.") };
+                }
+                
+                theRecipient = recipient[key];
             }
-            theRecipient = recipient[key];
-            return;
         }
-    });
+    }
     
     if (!theRecipient) {
-        err = new Error("Failed to extract recipient from '" + Object.keys(recipient) + "'. Valid keys: '" + validArrayKeys.join(', ') + ', ' + validStringKeys.join(', ') + "'");
+        return { 
+            err: new Error("Failed to extract recipient from '" + Object.keys(recipient) + "'. Valid keys: '" + validRecipientKeys['String'].join(', ') + ', ' + validRecipientKeys['Array'].join(', ') + "'.") 
+        };
     }
 
     return {
-        err: err,
+        err: null,
         recipient: theRecipient
     };
 }

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -51,7 +51,7 @@ function extractRecipient(recipient) {
         }
     });
     
-    if (!theRecipient ) {
+    if (!theRecipient) {
         err = new Error("Failed to extract recipient from '" + Object.keys(recipient) + "'. Valid keys: '" + validArrayKeys.join(', ') + ', ' + validStringKeys.join(', ') + "'");
     }
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,20 +27,36 @@ var parseAndRespond = function(resBody, callback) {
 };
 
 function extractRecipient(recipient) {
-    var validKeys = ['registrationIds', 'registrationTokens', 'topic', 'notificationKey'];
-    var theRecipient;
+    var validStringKeys = ['topic', 'notificationKey'];
+    var validArrayKeys = ['registrationIds', 'registrationTokens'];
+    var theRecipient, err;
 
-    validKeys.forEach(function(key) {
+    validArrayKeys.forEach(function(key) {
         if (recipient[key]) {
+            if (!Array.isArray(recipient[key])) {
+                err = new Error("Recipient key '" + key + "' should be provided as an array.");
+            }
             theRecipient = recipient[key];
             return;
         }
     });
+    
+    validStringKeys.forEach(function(key) {
+        if (recipient[key]) {
+            if ( typeof recipient[key] != "string" ) {
+                err = new Error("Recipient key '" + key + "' should be provided as a string.");
+            }
+            theRecipient = recipient[key];
+            return;
+        }
+    });
+    
+    if (!theRecipient ) {
+        err = new Error("Failed to extract recipient from '" + Object.keys(recipient) + "'. Valid keys: '" + validArrayKeys.join(', ') + ', ' + validStringKeys.join(', ') + "'");
+    }
 
     return {
-        err: theRecipient ?
-            null :
-            'Invalid recipient key(s) ' + Object.keys(recipient) + ' (valid keys: ' + validKeys.join(', ') + ')',
+        err: err,
         recipient: theRecipient
     };
 }
@@ -200,10 +216,13 @@ Sender.prototype.send = function(message, recipient, options, callback) {
 
         // check for bad tokens
         var unsentRegTokens = [], regTokenPositionMap = [];
+        
+        // Count recipients (handle string recipients as well)
+        var recipientCount = Array.isArray(recipient) ? recipient.length : 1;
 
         // Responses for messages sent a topic just contain { message_id: '...' } or { error: '...' }
         if (response.results) {
-            for (var i = 0; i < recipient.length; i++) {
+            for (var i = 0; i < recipientCount; i++) {
                 if (response.results[i].error === 'Unavailable') {
                     regTokenPositionMap.push(i);
                     unsentRegTokens.push(recipient[i]);

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -230,6 +230,14 @@ describe('UNIT Sender', function () {
       expect(callback.args[0][0]).to.be.a('object');
     });
 
+    it('should pass an error into callback if provided more than one recipient key', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {registrationIds: ['string'], topic: 'string'}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+
     it('should pass an error into callback if registrationIds is not an array', function () {
       var callback = sinon.spy();
       var sender = new Sender('myKey');

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -262,6 +262,22 @@ describe('UNIT Sender', function () {
       expect(callback.args[0][0]).to.be.a('object');
     });
     
+    it('should pass an error into callback if topic is empty', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {topic: ''}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+    
+    it('should pass an error into callback if notificationKey is empty', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {notificationKey: ''}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+    
     it('should pass an error into callback if no recipient provided', function () {
       var callback = sinon.spy();
       var sender = new Sender('myKey');

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -219,15 +219,55 @@ describe('UNIT Sender', function () {
       var sender = new Sender('myKey');
       sender.sendNoRetry(new Message(), {}, callback);
       expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][0]).to.be.a('string');
+      expect(callback.args[0][0]).to.be.a('object');
     });
 
     it('should pass an error into callback if recipient keys are invalid', function () {
       var callback = sinon.spy();
       var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {invalid: true}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+
+    it('should pass an error into callback if registrationIds is not an array', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {registrationIds: 'string'}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+    
+    it('should pass an error into callback if registrationTokens is not an array', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {registrationTokens: 'string'}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+    
+    it('should pass an error into callback if topic is not a string', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {topic: ['array']}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+    
+    it('should pass an error into callback if notificationKey is not a string', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {notificationKey: ['array']}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+    
+    it('should pass an error into callback if no recipient provided', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
       sender.sendNoRetry(new Message(), {}, callback);
       expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][0]).to.be.a('string');
+      expect(callback.args[0][0]).to.be.a('object');
     });
 
     it('should pass an error into callback if request returns an error', function () {
@@ -360,7 +400,7 @@ describe('UNIT Sender', function () {
 
     it('should pass an error into callback if recipient is an empty object', function (done) {
       var callback = function(error) {
-        expect(error).to.be.a('string');
+        expect(error).to.be.a('object');
         done();
       };
       var sender = new Sender('myKey');
@@ -369,7 +409,7 @@ describe('UNIT Sender', function () {
 
     it('should pass an error into callback if recipient keys are invalid', function (done) {
       var callback = function(error) {
-        expect(error).to.be.a('string');
+        expect(error).to.be.a('object');
         done();
       };
       var sender = new Sender('myKey');

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -403,8 +403,6 @@ describe('UNIT Sender', function () {
       Sender.prototype.sendNoRetry = restore.sendNoRetry;
     });
 
-    it.skip('should do something if passed not an array for regTokens');
-
     it('should pass an error into callback if array has no regTokens', function (done) {
       var callback = function(error) {
         expect(error).to.be.a('string');


### PR DESCRIPTION
Closes #186.

Returns an error to the callback in the following circumstances:
1. No valid recipient key was provided
2. A string recipient key (topic, notificationKey) was provided, but was not a string
3. An array recipient key (registrationIds, registrationTokens) was provided, but was not an array
4. A valid recipient key was provided but contained false/null/undefined/empty string

In addition:
* Added better handling for the unsent registration tokens detection, in case of a string recipient (it was not handled properly)
* Added tests to check for recipient errors
* Added tests to check for empty string recipients
* Removed a previously skipped test which has been implemented
* Listed recipient keys and types in README.md along with error-handling behavior