### PR TITLE
Improved support for unicast messaging (sending to one device)

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -74,7 +74,12 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
         }
     }
     else {
-        body.registration_ids = recipient;
+        if (Array.isArray(recipient) && recipient.length == 1) {
+            body.to = recipient[0];
+        }
+        else {
+            body.registration_ids = recipient;
+        }
     }
 
     var requestBody = JSON.stringify(body);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -162,10 +162,7 @@ Sender.prototype.send = function(message, recipient, options, callback) {
         callback = function() {};
     }
 
-    if(typeof recipient == "string") {
-        recipient = [recipient];
-    }
-    else if (!Array.isArray(recipient) && typeof recipient == "object") {
+    if (!Array.isArray(recipient) && typeof recipient == "object") {
         // For topics, passing them to sendNoRetry() as if they were registration tokens
         // will put them in the "to" value of the JSON payload, which what we want
         var o = extractRecipient(recipient);

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -204,6 +204,36 @@ describe('UNIT Sender', function () {
       expect(body.registration_ids).to.be.an("undefined");
     })
 
+    it('should set the to field if a single reg token is passed inside the recipient array', function() {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      var token = "registration token 1";
+      sender.sendNoRetry(m, [ token ], function () {});
+      var body = JSON.parse(args.options.body);
+      expect(body.to).to.deep.equal(token);
+      expect(body.registration_ids).to.be.an("undefined");
+    })
+
+    it('should set the to field if a single reg token is passed inside the registrationTokens array', function() {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      var token = "registration token 1";
+      sender.sendNoRetry(m, { registrationTokens: token }, function () {});
+      var body = JSON.parse(args.options.body);
+      expect(body.to).to.deep.equal(token);
+      expect(body.registration_ids).to.be.an("undefined");
+    })
+
+    it('should set the to field if a single reg token is passed inside the registrationIDs array', function() {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      var token = "registration token 1";
+      sender.sendNoRetry(m, { registrationIDs: token }, function () {});
+      var body = JSON.parse(args.options.body);
+      expect(body.to).to.deep.equal(token);
+      expect(body.registration_ids).to.be.an("undefined");
+    })
+
     it('should set the to field if a topic is passed in', function() {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -204,6 +204,16 @@ describe('UNIT Sender', function () {
       expect(body.registration_ids).to.be.an("undefined");
     })
 
+    it('should set the to field if a single reg token is passed in as a string', function() {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      var token = "registration token 1";
+      sender.sendNoRetry(m, token, function () {});
+      var body = JSON.parse(args.options.body);
+      expect(body.to).to.deep.equal(token);
+      expect(body.registration_ids).to.be.an("undefined");
+    })
+
     it('should set the to field if a single reg token is passed inside the recipient array', function() {
       var sender = new Sender('myKey');
       var m = new Message({ data: {} });


### PR DESCRIPTION
As per @alemonmk's suggestion in #187, when supplying a single registration token inside an array, we should set the `to` property and not the `registration_ids` property, so that the push notification will be sent as a unicast message, which is encouraged by the [GCM documentation](https://developers.google.com/cloud-messaging/http-server-ref#table1).

To achieve this, I added a check for a single-element array inside `sendNoRetry`.

The response from the GCM server is identical for unicast and multicast messages.

Also, added the following tests to check for correct utilization of the `to` GCM request property:
* Should set the to field if a single reg token is passed inside the recipient array
* Should set the to field if a single reg token is passed inside the registrationTokens array
* Should set the to field if a single reg token is passed inside the registrationIDs array

@hypesystem Please confirm. =)