### PR TITLE
Fixes #192 Support Authorization header as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ You can provide custom `request` options such as `proxy` and `timeout` for the G
 // Set custom request options
 var requestOptions = {
 	proxy: 'http://127.0.0.1:8888',
-	timeout: 5000
+	timeout: 5000,
+	Authorization: 'key=YOUR_AUTHORIZATION_KEY_HERE'
 };
 
 // Set up the sender with your API key and request options

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -84,7 +84,7 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
         headers: {
             'Content-Type': 'application/json',
             'Content-length': Buffer.byteLength(requestBody, 'utf8'),
-            'Authorization': 'key=' + this.key
+            'Authorization': this.options.Authorization || 'key=' + this.key
         },
         uri: Constants.GCM_SEND_URI,
         body: requestBody


### PR DESCRIPTION
Original code uses GCM Api key as Authorization header, but this doesn't work.
Just to be sure, I left the original code in as fallback as I don't know if this is legacy code or not.

Updated README as well to show an example of an authorization header value.

```js
// Set custom request options
var requestOptions = {
	proxy: 'http://127.0.0.1:8888',
	timeout: 5000,
	Authorization: 'key=YOUR_AUTHORIZATION_KEY_HERE'
};