### PR TITLE
Avoid retry for 4xx HTTP status codes

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -174,6 +174,13 @@ Sender.prototype.send = function(message, recipient, options, callback) {
     this.sendNoRetry(message, recipient, function(err, response) {
         // if we err'd resend them all
         if (err) {
+            // No retry for 4xx client errors
+            if (typeof err === 'number' && err > 399 && err < 500) {
+                // Return error to original callback
+                return callback(err);
+            }
+            
+            // Retry until we run out of tries
             return setTimeout(function() {
                 self.send(message, originalRecipient, {
                     retries: retries - 1,


### PR DESCRIPTION
As per #145, added a check for `4xx` status code responses, which are a result of a client error.

We should not retry requests that failed due to a client error, since we’d probably be making the same mistake again in the next request(s).