### PR TITLE
Add "to" recipient key

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ You can send push notifications to various recipient types by providing one of t
 
 |Key|Type|Description|
 |---|---|---|
-|topic|String|A [GCM PubSub](https://developers.google.com/cloud-messaging/topic-messaging) topic.
+|to|String|A single [registration token](https://developers.google.com/cloud-messaging/android/client#sample-register), [notification key](https://developers.google.com/cloud-messaging/notifications), or [topic](https://developers.google.com/cloud-messaging/topic-messaging).
+|topic|String|A single publish/subscribe topic.
 |notificationKey|String|Deprecated. A key that groups multiple registration tokens linked to the same user.
 |registrationIds|String[]|Deprecated. Use registrationTokens instead.|
 |registrationTokens|String[]|A list of registration tokens. Must contain at least 1 and at most 1000 registration tokens.|

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -30,6 +30,7 @@ function extractRecipient(recipient) {
     }
 
     var keyValidators = {
+        to: isString,
         topic: isString,
         notificationKey: isString,
         registrationIds: isArray,

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -254,6 +254,16 @@ describe('UNIT Sender', function () {
       expect(body.registration_ids).to.be.an("undefined");
     })
 
+    it('should set the to field if a to recipient is passed in', function() {
+      var sender = new Sender('myKey');
+      var m = new Message({ data: {} });
+      var token = "registration token 1";
+      sender.sendNoRetry(m, { to: token }, function () {});
+      var body = args.options.json;
+      expect(body.to).to.deep.equal(token);
+      expect(body.registration_ids).to.be.an("undefined");
+    })
+
     it('should pass an error into callback if recipient is an empty object', function () {
       var callback = sinon.spy();
       var sender = new Sender('myKey');
@@ -294,6 +304,14 @@ describe('UNIT Sender', function () {
       expect(callback.args[0][0]).to.be.a('object');
     });
     
+    it('should pass an error into callback if to is not a string', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {to: ['array']}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+    
     it('should pass an error into callback if topic is not a string', function () {
       var callback = sinon.spy();
       var sender = new Sender('myKey');
@@ -306,6 +324,14 @@ describe('UNIT Sender', function () {
       var callback = sinon.spy();
       var sender = new Sender('myKey');
       sender.sendNoRetry(new Message(), {notificationKey: ['array']}, callback);
+      expect(callback.calledOnce).to.be.ok;
+      expect(callback.args[0][0]).to.be.a('object');
+    });
+    
+    it('should pass an error into callback if to is empty', function () {
+      var callback = sinon.spy();
+      var sender = new Sender('myKey');
+      sender.sendNoRetry(new Message(), {to: ''}, callback);
       expect(callback.calledOnce).to.be.ok;
       expect(callback.args[0][0]).to.be.a('object');
     });


### PR DESCRIPTION
As per https://github.com/ToothlessGear/node-gcm/issues/187#issuecomment-167965048, we decided to add a new recipient key, `to`, that accepts a registration token, pub/sub topic, or a notification key.

* Added extraction code to `extractRecipient`
* Added several tests to check for `to` key existence/behavior
* Added to recipient keys documentation in `README.md`