### PR TITLE
Add npm badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # node-gcm
+[![npm](https://badge.fury.io/js/node-gcm.svg)](https://www.npmjs.com/package/node-gcm)
 
 node-gcm is a Node.JS library for [**Google Cloud Messaging**](https://developers.google.com/cloud-messaging/).
 


### PR DESCRIPTION
As per #201, we decided to add a badge linking to the `node-gcm` npm package, displaying its latest version number as well.

@hypesystem fyi