### PR TITLE
V1: Depend only on lodash.defaultsdeep (instead of all lodash)

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1,5 +1,5 @@
 var Constants = require('./constants');
-var _ = require('lodash');
+var defaultsDeep = require('lodash.defaultsdeep');
 var request = require('request');
 var debug = require('debug')('node-gcm');
 
@@ -135,7 +135,7 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
         }
 
         //Build request options, allowing some to be overridden
-        var request_options = _.defaultsDeep({
+        var request_options = defaultsDeep({
             method: 'POST',
             headers: {
                 'Authorization': 'key=' + this.key

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "debug": "^0.8.1",
-    "lodash": "^3.10.1",
+    "lodash.defaultsdeep": "^4.4.0",
     "request": "^2.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This makes for a significantly smaller dependency tree (lodash is 2Mb, lodash.defaultsdeep is around 250kb)