### PR TITLE
V1: simpler recipient arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ gcm.send(message, registrationTokens, 10, function (err, response) {
 
 ## Recipients
 
-You can send a push notification to various recipient or topic, by providing a notification key, registration token og topic as a string.
+You can send a push notification to various recipient or topic, by providing a notification key, registration token or topic as a string.
 Alternatively, you can send it to several recipients at once, by providing an array of registration tokens.
 
 Notice that [you can *at most* send notifications to 1000 registration tokens at a time](https://github.com/ToothlessGear/node-gcm/issues/42).

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ var gcm = require('node-gcm')('YOUR_API_KEY_HERE');
 var message = {
     data: { key1: 'msg1' }
 };
-var regTokens = ['YOUR_REG_TOKEN_HERE'];
+var recipient = 'YOUR_REG_TOKEN_HERE';
 
-gcm.send(message, { registrationTokens: regTokens }, function (err, response) {
+gcm.send(message, recipient, function (err, response) {
 	if(err) console.error(err);
 	else 	console.log(response);
 });
@@ -78,19 +78,19 @@ registrationTokens.push('regToken2');
 
 // Send the message
 // ... trying only once
-gcm.sendNoRetry(message, { registrationTokens: registrationTokens }, function(err, response) {
+gcm.sendNoRetry(message, registrationTokens, function(err, response) {
   if(err) console.error(err);
   else    console.log(response);
 });
 
 // ... or retrying
-gcm.send(message, { registrationTokens: registrationTokens }, function (err, response) {
+gcm.send(message, registrationTokens, function (err, response) {
   if(err) console.error(err);
   else    console.log(response);
 });
 
 // ... or retrying a specific number of times (10)
-gcm.send(message, { registrationTokens: registrationTokens }, 10, function (err, response) {
+gcm.send(message, registrationTokens, 10, function (err, response) {
   if(err) console.error(err);
   else    console.log(response);
 });
@@ -98,17 +98,8 @@ gcm.send(message, { registrationTokens: registrationTokens }, 10, function (err,
 
 ## Recipients
 
-You can send push notifications to various recipient types by providing one of the following recipient keys:
-
-|Key|Type|Description|
-|---|---|---|
-|to|String|A single [registration token](https://developers.google.com/cloud-messaging/android/client#sample-register), [notification key](https://developers.google.com/cloud-messaging/notifications), or [topic](https://developers.google.com/cloud-messaging/topic-messaging).
-|topic|String|A single publish/subscribe topic.
-|notificationKey|String|Deprecated. A key that groups multiple registration tokens linked to the same user.
-|registrationIds|String[]|Deprecated. Use registrationTokens instead.|
-|registrationTokens|String[]|A list of registration tokens. Must contain at least 1 and at most 1000 registration tokens.|
-
-If you provide an incorrect recipient key or object type, an `Error` object will be returned to your callback.
+You can send a push notification to various recipient or topic, by providing a notification key, registration token og topic as a string.
+Alternatively, you can send it to several recipients at once, by providing an array of registration tokens.
 
 Notice that [you can *at most* send notifications to 1000 registration tokens at a time](https://github.com/ToothlessGear/node-gcm/issues/42).
 This is due to [a restriction](http://developer.android.com/training/cloudsync/gcm.html) on the side of the GCM API.
@@ -161,9 +152,9 @@ var gcm = require("node-gcm")('YOUR_API_KEY_HERE', requestOptions);
 // Prepare a GCM message...
 
 // Send it to GCM endpoint with modified request options
-gcm.send(message, { registrationTokens: regTokens }, function (err, response) {
+gcm.send(message, regTokens, function (err, response) {
     if(err) console.error(err);
-    else     console.log(response);
+    else    console.log(response);
 });
 ```
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -177,12 +177,12 @@ function getRequestBody(message, recipient, callback) {
     }
     if(Array.isArray(recipient)) {
         if(recipient.length < 1) {
-            return nextTick(callback, 'Empty recipient array passed!');
+            return nextTick(callback, new Error('Empty recipient array passed!'));
         }
         body.registration_ids = recipient;
         return nextTick(callback, null, body);
     }
-    return nextTick(callback, 'Invalid recipient (' + recipient + ', type ' + typeof recipient + ') provided (must be array or string)!');
+    return nextTick(callback, new Error('Invalid recipient (' + recipient + ', type ' + typeof recipient + ') provided (must be array or string)!'));
 }
 
 function cleanParams(raw) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -176,30 +176,10 @@ function getRequestBody(message, recipient, callback) {
         return nextTick(callback, null, body);
     }
     if(Array.isArray(recipient)) {
-        if(!recipient.length) {
-            return nextTick(callback, 'No recipient provided!');
-        }
-        else if(recipient.length == 1) {
-            body.to = recipient[0];
-            return nextTick(callback, null, body);
-        }
         body.registration_ids = recipient;
         return nextTick(callback, null, body);
     }
-    if (typeof recipient == "object") {
-        return extractRecipient(recipient, function(err, recipient) {
-            if(err) {
-                return callback(err);
-            }
-            if (Array.isArray(recipient)) {
-                body.registration_ids = recipient;
-                return callback(null, body);
-            }
-            body.to = recipient;
-            return callback(null, body);
-        });
-    }
-    return nextTick(callback, 'Invalid recipient (' + recipient + ', type ' + typeof recipient + ') provided!');
+    return nextTick(callback, 'Invalid recipient (' + recipient + ', type ' + typeof recipient + ') provided (must be array or string)!');
 }
 
 function cleanParams(raw) {
@@ -222,47 +202,6 @@ function nextTick(func) {
     process.nextTick(function() {
         func.apply(this, args);
     }.bind(this));
-}
-
-function extractRecipient(recipient, callback) {
-    var recipientKeys = Object.keys(recipient);
-
-    if(recipientKeys.length !== 1) {
-        return nextTick(callback, new Error("Please specify exactly one recipient key (you specified [" + recipientKeys + "])"));
-    }
-
-    var key = recipientKeys[0];
-    var value  = recipient[key];
-
-    if(!value) {
-        return nextTick(callback, new Error("Falsy value for recipient key '" + key + "'."));
-    }
-
-    var keyValidators = {
-        to: isString,
-        topic: isString,
-        notificationKey: isString,
-        registrationIds: isArray,
-        registrationTokens: isArray
-    };
-
-    var validator = keyValidators[key];
-    if(!validator) {
-        return nextTick(callback, new Error("Key '" + key + "' is not a valid recipient key."));
-    }
-    if(!validator(value)) {
-        return nextTick(callback, new Error("Recipient key '" + key + "' was provided as an incorrect type."));
-    }
-
-    return nextTick(callback, null, value);
-}
-
-function isString(x) {
-    return typeof x == "string";
-}
-
-function isArray(x) {
-    return Array.isArray(x);
 }
 
 module.exports = Sender;

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -176,6 +176,9 @@ function getRequestBody(message, recipient, callback) {
         return nextTick(callback, null, body);
     }
     if(Array.isArray(recipient)) {
+        if(recipient.length < 1) {
+            return nextTick(callback, 'Empty recipient array passed!');
+        }
         body.registration_ids = recipient;
         return nextTick(callback, null, body);
     }

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -263,67 +263,15 @@ describe('UNIT Sender', function () {
       }, 10);
     })
 
-    it('should set the to field if a single reg token is passed inside the recipient array', function(done) {
+    it('should set the registration_id field if a single reg token is passed inside the recipient array', function(done) {
       var sender = new Sender('myKey');
       var m = { data: {} };
       var token = "registration token 1";
       sender.sendNoRetry(m, [ token ], function () {});
       setTimeout(function() {
         var body = args.options.json;
-        expect(body.to).to.deep.equal(token);
-        expect(body.registration_ids).to.be.an("undefined");
-        done();
-      }, 10);
-    })
-
-    it('should set the to field if a single reg token is passed inside the registrationTokens array', function(done) {
-      var sender = new Sender('myKey');
-      var m = { data: {} };
-      var token = "registration token 1";
-      sender.sendNoRetry(m, { registrationTokens: token }, function () {});
-      setTimeout(function() {
-        var body = args.options.json;
-        expect(body.to).to.deep.equal(token);
-        expect(body.registration_ids).to.be.an("undefined");
-        done();
-      }, 10);
-    })
-
-    it('should set the to field if a single reg token is passed inside the registrationIDs array', function(done) {
-      var sender = new Sender('myKey');
-      var m = { data: {} };
-      var token = "registration token 1";
-      sender.sendNoRetry(m, { registrationIDs: token }, function () {});
-      setTimeout(function() {
-        var body = args.options.json;
-        expect(body.to).to.deep.equal(token);
-        expect(body.registration_ids).to.be.an("undefined");
-        done();
-      }, 10);
-    })
-
-    it('should set the to field if a topic is passed in', function(done) {
-      var sender = new Sender('myKey');
-      var m = { data: {} };
-      var topic = '/topics/tests';
-      sender.sendNoRetry(m, { topic: topic }, function () {});
-      setTimeout(function() {
-        var body = args.options.json;
-        expect(body.to).to.deep.equal(topic);
-        expect(body.registration_ids).to.be.an("undefined");
-        done();
-      }, 10);
-    })
-
-    it('should set the to field if a to recipient is passed in', function(done) {
-      var sender = new Sender('myKey');
-      var m = { data: {} };
-      var token = "registration token 1";
-      sender.sendNoRetry(m, { to: token }, function () {});
-      setTimeout(function() {
-        var body = args.options.json;
-        expect(body.to).to.deep.equal(token);
-        expect(body.registration_ids).to.be.an("undefined");
+        expect(body.registration_ids).to.deep.equal([ token ]);
+        expect(body.to).to.be.an("undefined");
         done();
       }, 10);
     })
@@ -339,120 +287,10 @@ describe('UNIT Sender', function () {
       }, 10);
     });
 
-    it('should pass an error into callback if recipient keys are invalid', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {invalid: true}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if provided more than one recipient key', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {registrationIds: ['string'], topic: 'string'}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if registrationIds is not an array', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {registrationIds: 'string'}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if registrationTokens is not an array', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {registrationTokens: 'string'}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if to is not a string', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {to: ['array']}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if topic is not a string', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {topic: ['array']}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if notificationKey is not a string', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {notificationKey: ['array']}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if to is empty', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {to: ''}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if topic is empty', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {topic: ''}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
-    it('should pass an error into callback if notificationKey is empty', function (done) {
-      var callback = sinon.spy();
-      var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {notificationKey: ''}, callback);
-      setTimeout(function() {
-        expect(callback.calledOnce).to.be.ok;
-        expect(callback.args[0][0]).to.be.a('object');
-        done();
-      }, 10);
-    });
-
     it('should pass an error into callback if no recipient provided', function (done) {
       var callback = sinon.spy();
       var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {}, callback);
+      sender.sendNoRetry({}, [], callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.args[0][0]).to.be.a('object');


### PR DESCRIPTION
Note: this merges into `v1`.

Simplified the way we pass recipients to the send function: now much simpler. This moves us much closer to the interface of the HTTP api, removes a lot of pretty unnecessary cruft and tests, and makes everything simpler and easier to get an overview of.