### PR TITLE
V1 no send no retry

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -126,10 +126,6 @@ function updateResponseMetaData(response, retriedResponse, unsentRegTokens) {
 }
 
 function sendMessage(key, options, message, recipient, callback) {
-    if(!callback) {
-        callback = function() {};
-    }
-
     getRequestBody(message, recipient, function(err, body) {
         if(err) {
             return callback(err);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -141,7 +141,7 @@ function sendMessageWithRetries(requestOptions, body, messageOptions, callback) 
 }
 
 function retry(requestOptions, body, messageOptions, callback) {
-    return setTimeout(function() {
+    setTimeout(function() {
         sendMessageWithRetries(requestOptions, body, {
             retries: messageOptions.retries - 1,
             backoff: messageOptions.backoff * 2

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -62,7 +62,7 @@ function sendMessageWithRetries(self, key, senderOptions, message, recipient, me
                 debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
                 return callback(err);
             }
-            return retry(self, message, recipient, messageOptions, callback);
+            return retry(self, key, senderOptions, message, recipient, messageOptions, callback);
         }
         if(!response.results) {
             return callback(null, response);
@@ -77,7 +77,7 @@ function sendMessageWithRetries(self, key, senderOptions, message, recipient, me
 
             debug("Retrying " + unsentRegTokens.length + " unsent registration tokens");
 
-            retry(self, message, unsentRegTokens, messageOptions, function(err, retriedResponse) {
+            retry(self, key, senderOptions, message, unsentRegTokens, messageOptions, function(err, retriedResponse) {
                 if(err) {
                     return callback(null, response);
                 }
@@ -88,13 +88,13 @@ function sendMessageWithRetries(self, key, senderOptions, message, recipient, me
     });
 }
 
-function retry(self, message, recipient, options, callback) {
+function retry(self, key, senderOptions, message, recipient, messageOptions, callback) {
     return setTimeout(function() {
-        self.send(message, recipient, {
-            retries: options.retries - 1,
-            backoff: options.backoff * 2
+        sendMessageWithRetries(self, key, senderOptions, message, recipient, {
+            retries: messageOptions.retries - 1,
+            backoff: messageOptions.backoff * 2
         }, callback);
-    }, options.backoff);
+    }, messageOptions.backoff);
 }
 
 function checkForBadTokens(results, originalRecipients, callback) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -24,12 +24,12 @@ Sender.prototype.send = function(message, recipient, options, callback) {
     options = cleanOptions(options);
 
     if(options.retries == 0) {
-        return sendNoRetry(this.key, this.options, message, recipient, callback);
+        return sendMessage(this.key, this.options, message, recipient, callback);
     }
 
     var self = this;
 
-    sendNoRetry(this.key, this.options, message, recipient, function(err, response, attemptedRegTokens) {
+    sendMessage(this.key, this.options, message, recipient, function(err, response, attemptedRegTokens) {
         if (err) {
             if (typeof err === 'number' && err > 399 && err < 500) {
                 debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
@@ -125,7 +125,7 @@ function updateResponseMetaData(response, retriedResponse, unsentRegTokens) {
     response.failure -= unsentRegTokens.length - retriedResponse.failure;
 }
 
-function sendNoRetry(key, options, message, recipient, callback) {
+function sendMessage(key, options, message, recipient, callback) {
     if(!callback) {
         callback = function() {};
     }

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -66,6 +66,45 @@ function cleanOptions(options) {
     return options;
 }
 
+function getRequestBody(message, recipient, callback) {
+    var body = cleanParams(message);
+
+    if(typeof recipient == "string") {
+        body.to = recipient;
+        return nextTick(callback, null, body);
+    }
+    if(Array.isArray(recipient)) {
+        if(recipient.length < 1) {
+            return nextTick(callback, new Error('Empty recipient array passed!'));
+        }
+        body.registration_ids = recipient;
+        return nextTick(callback, null, body);
+    }
+    return nextTick(callback, new Error('Invalid recipient (' + recipient + ', type ' + typeof recipient + ') provided (must be array or string)!'));
+}
+
+function cleanParams(raw) {
+    var params = {};
+    Object.keys(raw).forEach(function(param) {
+        var paramOptions = messageOptions[param];
+        if(!paramOptions) {
+            return console.warn("node-gcm ignored unknown message parameter " + param);
+        }
+        if(paramOptions.__argType != typeof raw[param]) {
+            return console.warn("node-gcm ignored wrongly typed message parameter " + param + " (was " + typeof raw[param] + ", expected " + paramOptions.__argType + ")");
+        }
+        params[param] = raw[param];
+    });
+    return params;
+}
+
+function nextTick(func) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    process.nextTick(function() {
+        func.apply(this, args);
+    }.bind(this));
+}
+
 function sendMessageWithRetries(requestOptions, body, messageOptions, callback) {
     sendMessage(requestOptions, body, function(err, response, attemptedRegTokens) {
         if (err) {
@@ -160,45 +199,6 @@ function sendMessage(requestOptions, body, callback) {
         }
         callback(null, resBodyJSON, body.registration_ids || [ body.to ]);
     });
-}
-
-function getRequestBody(message, recipient, callback) {
-    var body = cleanParams(message);
-
-    if(typeof recipient == "string") {
-        body.to = recipient;
-        return nextTick(callback, null, body);
-    }
-    if(Array.isArray(recipient)) {
-        if(recipient.length < 1) {
-            return nextTick(callback, new Error('Empty recipient array passed!'));
-        }
-        body.registration_ids = recipient;
-        return nextTick(callback, null, body);
-    }
-    return nextTick(callback, new Error('Invalid recipient (' + recipient + ', type ' + typeof recipient + ') provided (must be array or string)!'));
-}
-
-function cleanParams(raw) {
-    var params = {};
-    Object.keys(raw).forEach(function(param) {
-        var paramOptions = messageOptions[param];
-        if(!paramOptions) {
-            return console.warn("node-gcm ignored unknown message parameter " + param);
-        }
-        if(paramOptions.__argType != typeof raw[param]) {
-            return console.warn("node-gcm ignored wrongly typed message parameter " + param + " (was " + typeof raw[param] + ", expected " + paramOptions.__argType + ")");
-        }
-        params[param] = raw[param];
-    });
-    return params;
-}
-
-function nextTick(func) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    process.nextTick(function() {
-        func.apply(this, args);
-    }.bind(this));
 }
 
 module.exports = Sender;

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,11 +27,10 @@ Sender.prototype.send = function(message, recipient, options, callback) {
         if(err) {
             return callback(err);
         }
-    if(options.retries == 0) {
-        return sendMessage(this.key, this.options, body, callback);
-    }
-
-    sendMessageWithRetries(this.key, this.options, body, options, callback);
+        if(options.retries == 0) {
+            return sendMessage(this.key, this.options, body, callback);
+        }
+        sendMessageWithRetries(this.key, this.options, body, options, callback);
     }.bind(this));
 };
 
@@ -135,36 +134,36 @@ function updateResponseMetaData(response, retriedResponse, unsentRegTokens) {
 }
 
 function sendMessage(key, options, body, callback) {
-        //Build request options, allowing some to be overridden
-        var request_options = defaultsDeep({
-            method: 'POST',
-            headers: {
-                'Authorization': 'key=' + key
-            },
-            uri: Constants.GCM_SEND_URI,
-            json: body
-        }, options, {
-            timeout: Constants.SOCKET_TIMEOUT
-        });
+    //Build request options, allowing some to be overridden
+    var request_options = defaultsDeep({
+        method: 'POST',
+        headers: {
+            'Authorization': 'key=' + key
+        },
+        uri: Constants.GCM_SEND_URI,
+        json: body
+    }, options, {
+        timeout: Constants.SOCKET_TIMEOUT
+    });
 
-        request(request_options, function (err, res, resBodyJSON) {
-            if (err) {
-                return callback(err);
-            }
-            if (res.statusCode >= 500) {
-                debug('GCM service is unavailable (500)');
-                return callback(res.statusCode);
-            }
-            if (res.statusCode === 401) {
-                debug('Unauthorized (401). Check that your API token is correct.');
-                return callback(res.statusCode);
-            }
-            if (res.statusCode !== 200) {
-                debug('Invalid request (' + res.statusCode + '): ' + resBodyJSON);
-                return callback(res.statusCode);
-            }
-            callback(null, resBodyJSON, body.registration_ids || [ body.to ]);
-        });
+    request(request_options, function (err, res, resBodyJSON) {
+        if (err) {
+            return callback(err);
+        }
+        if (res.statusCode >= 500) {
+            debug('GCM service is unavailable (500)');
+            return callback(res.statusCode);
+        }
+        if (res.statusCode === 401) {
+            debug('Unauthorized (401). Check that your API token is correct.');
+            return callback(res.statusCode);
+        }
+        if (res.statusCode !== 200) {
+            debug('Invalid request (' + res.statusCode + '): ' + resBodyJSON);
+            return callback(res.statusCode);
+        }
+        callback(null, resBodyJSON, body.registration_ids || [ body.to ]);
+    });
 }
 
 function getRequestBody(message, recipient, callback) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -9,8 +9,15 @@ function Sender(key, options) {
         return new Sender(key, options);
     }
 
-    this.key = key;
-    this.options = options || {};
+    this.requestOptions = defaultsDeep({
+        method: 'POST',
+        headers: {
+            'Authorization': 'key=' + key
+        },
+        uri: Constants.GCM_SEND_URI
+    }, options, {
+        timeout: Constants.SOCKET_TIMEOUT
+    });
 }
 
 Sender.prototype.send = function(message, recipient, options, callback) {
@@ -28,9 +35,9 @@ Sender.prototype.send = function(message, recipient, options, callback) {
             return callback(err);
         }
         if(options.retries == 0) {
-            return sendMessage(this.key, this.options, body, callback);
+            return sendMessage(this.requestOptions, body, callback);
         }
-        sendMessageWithRetries(this.key, this.options, body, options, callback);
+        sendMessageWithRetries(this.requestOptions, body, options, callback);
     }.bind(this));
 };
 
@@ -59,14 +66,14 @@ function cleanOptions(options) {
     return options;
 }
 
-function sendMessageWithRetries(key, senderOptions, body, messageOptions, callback) {
-    sendMessage(key, senderOptions, body, function(err, response, attemptedRegTokens) {
+function sendMessageWithRetries(requestOptions, body, messageOptions, callback) {
+    sendMessage(requestOptions, body, function(err, response, attemptedRegTokens) {
         if (err) {
             if (typeof err === 'number' && err > 399 && err < 500) {
                 debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
                 return callback(err);
             }
-            return retry(key, senderOptions, body, messageOptions, callback);
+            return retry(requestOptions, body, messageOptions, callback);
         }
         //TODO: Figure out why this case exists -- should it be removed?
         if(!response.results) {
@@ -83,7 +90,7 @@ function sendMessageWithRetries(key, senderOptions, body, messageOptions, callba
             debug("Retrying " + unsentRegTokens.length + " unsent registration tokens");
 
             body.registration_ids = unsentRegTokens;
-            retry(key, senderOptions, body, messageOptions, function(err, retriedResponse) {
+            retry(requestOptions, body, messageOptions, function(err, retriedResponse) {
                 if(err) {
                     return callback(null, response);
                 }
@@ -94,9 +101,9 @@ function sendMessageWithRetries(key, senderOptions, body, messageOptions, callba
     });
 }
 
-function retry(key, senderOptions, body, messageOptions, callback) {
+function retry(requestOptions, body, messageOptions, callback) {
     return setTimeout(function() {
-        sendMessageWithRetries(key, senderOptions, body, {
+        sendMessageWithRetries(requestOptions, body, {
             retries: messageOptions.retries - 1,
             backoff: messageOptions.backoff * 2
         }, callback);
@@ -133,20 +140,9 @@ function updateResponseMetaData(response, retriedResponse, unsentRegTokens) {
     response.failure -= unsentRegTokens.length - retriedResponse.failure;
 }
 
-function sendMessage(key, options, body, callback) {
-    //Build request options, allowing some to be overridden
-    var request_options = defaultsDeep({
-        method: 'POST',
-        headers: {
-            'Authorization': 'key=' + key
-        },
-        uri: Constants.GCM_SEND_URI,
-        json: body
-    }, options, {
-        timeout: Constants.SOCKET_TIMEOUT
-    });
-
-    request(request_options, function (err, res, resBodyJSON) {
+function sendMessage(requestOptions, body, callback) {
+    requestOptions.json = body;
+    request(requestOptions, function (err, res, resBodyJSON) {
         if (err) {
             return callback(err);
         }

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,38 +27,7 @@ Sender.prototype.send = function(message, recipient, options, callback) {
         return sendMessage(this.key, this.options, message, recipient, callback);
     }
 
-    var self = this;
-
-    sendMessage(this.key, this.options, message, recipient, function(err, response, attemptedRegTokens) {
-        if (err) {
-            if (typeof err === 'number' && err > 399 && err < 500) {
-                debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
-                return callback(err);
-            }
-            return retry(self, message, recipient, options, callback);
-        }
-        if(!response.results) {
-            return callback(null, response);
-        }
-        checkForBadTokens(response.results, attemptedRegTokens, function(err, unsentRegTokens, regTokenPositionMap) {
-            if(err) {
-                return callback(err);
-            }
-            if (unsentRegTokens.length == 0) {
-                return callback(null, response);
-            }
-
-            debug("Retrying " + unsentRegTokens.length + " unsent registration tokens");
-
-            retry(self, message, unsentRegTokens, options, function(err, retriedResponse) {
-                if(err) {
-                    return callback(null, response);
-                }
-                response = updateResponse(response, retriedResponse, regTokenPositionMap, unsentRegTokens);
-                callback(null, response);
-            });
-        });
-    });
+    sendMessageWithRetries(this, this.key, this.options, message, recipient, options, callback);
 };
 
 function cleanOptions(options) {
@@ -84,6 +53,39 @@ function cleanOptions(options) {
     }
 
     return options;
+}
+
+function sendMessageWithRetries(self, key, senderOptions, message, recipient, messageOptions, callback) {
+    sendMessage(key, senderOptions, message, recipient, function(err, response, attemptedRegTokens) {
+        if (err) {
+            if (typeof err === 'number' && err > 399 && err < 500) {
+                debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
+                return callback(err);
+            }
+            return retry(self, message, recipient, messageOptions, callback);
+        }
+        if(!response.results) {
+            return callback(null, response);
+        }
+        checkForBadTokens(response.results, attemptedRegTokens, function(err, unsentRegTokens, regTokenPositionMap) {
+            if(err) {
+                return callback(err);
+            }
+            if (unsentRegTokens.length == 0) {
+                return callback(null, response);
+            }
+
+            debug("Retrying " + unsentRegTokens.length + " unsent registration tokens");
+
+            retry(self, message, unsentRegTokens, messageOptions, function(err, retriedResponse) {
+                if(err) {
+                    return callback(null, response);
+                }
+                response = updateResponse(response, retriedResponse, regTokenPositionMap, unsentRegTokens);
+                callback(null, response);
+            });
+        });
+    });
 }
 
 function retry(self, message, recipient, options, callback) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -23,11 +23,16 @@ Sender.prototype.send = function(message, recipient, options, callback) {
     }
     options = cleanOptions(options);
 
+    getRequestBody(message, recipient, function(err, body) {
+        if(err) {
+            return callback(err);
+        }
     if(options.retries == 0) {
-        return sendMessage(this.key, this.options, message, recipient, callback);
+        return sendMessage(this.key, this.options, body, callback);
     }
 
-    sendMessageWithRetries(this.key, this.options, message, recipient, options, callback);
+    sendMessageWithRetries(this.key, this.options, body, options, callback);
+    }.bind(this));
 };
 
 function cleanOptions(options) {
@@ -55,14 +60,14 @@ function cleanOptions(options) {
     return options;
 }
 
-function sendMessageWithRetries(key, senderOptions, message, recipient, messageOptions, callback) {
-    sendMessage(key, senderOptions, message, recipient, function(err, response, attemptedRegTokens) {
+function sendMessageWithRetries(key, senderOptions, body, messageOptions, callback) {
+    sendMessage(key, senderOptions, body, function(err, response, attemptedRegTokens) {
         if (err) {
             if (typeof err === 'number' && err > 399 && err < 500) {
                 debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
                 return callback(err);
             }
-            return retry(key, senderOptions, message, recipient, messageOptions, callback);
+            return retry(key, senderOptions, body, messageOptions, callback);
         }
         //TODO: Figure out why this case exists -- should it be removed?
         if(!response.results) {
@@ -78,7 +83,8 @@ function sendMessageWithRetries(key, senderOptions, message, recipient, messageO
 
             debug("Retrying " + unsentRegTokens.length + " unsent registration tokens");
 
-            retry(key, senderOptions, message, unsentRegTokens, messageOptions, function(err, retriedResponse) {
+            body.registration_ids = unsentRegTokens;
+            retry(key, senderOptions, body, messageOptions, function(err, retriedResponse) {
                 if(err) {
                     return callback(null, response);
                 }
@@ -89,9 +95,9 @@ function sendMessageWithRetries(key, senderOptions, message, recipient, messageO
     });
 }
 
-function retry(key, senderOptions, message, recipient, messageOptions, callback) {
+function retry(key, senderOptions, body, messageOptions, callback) {
     return setTimeout(function() {
-        sendMessageWithRetries(key, senderOptions, message, recipient, {
+        sendMessageWithRetries(key, senderOptions, body, {
             retries: messageOptions.retries - 1,
             backoff: messageOptions.backoff * 2
         }, callback);
@@ -128,12 +134,7 @@ function updateResponseMetaData(response, retriedResponse, unsentRegTokens) {
     response.failure -= unsentRegTokens.length - retriedResponse.failure;
 }
 
-function sendMessage(key, options, message, recipient, callback) {
-    getRequestBody(message, recipient, function(err, body) {
-        if(err) {
-            return callback(err);
-        }
-
+function sendMessage(key, options, body, callback) {
         //Build request options, allowing some to be overridden
         var request_options = defaultsDeep({
             method: 'POST',
@@ -164,7 +165,6 @@ function sendMessage(key, options, message, recipient, callback) {
             }
             callback(null, resBodyJSON, body.registration_ids || [ body.to ]);
         });
-    });
 }
 
 function getRequestBody(message, recipient, callback) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -114,10 +114,6 @@ function sendMessageWithRetries(requestOptions, body, messageOptions, callback) 
             }
             return retry(requestOptions, body, messageOptions, callback);
         }
-        //TODO: Figure out why this case exists -- should it be removed?
-        if(!response.results) {
-            return callback(null, response);
-        }
         checkForBadTokens(response.results, attemptedRegTokens, function(err, unsentRegTokens, regTokenPositionMap) {
             if(err) {
                 return callback(err);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -24,12 +24,12 @@ Sender.prototype.send = function(message, recipient, options, callback) {
     options = cleanOptions(options);
 
     if(options.retries == 0) {
-        return this.sendNoRetry(message, recipient, callback);
+        return sendNoRetry(this.key, this.options, message, recipient, callback);
     }
 
     var self = this;
 
-    this.sendNoRetry(message, recipient, function(err, response, attemptedRegTokens) {
+    sendNoRetry(this.key, this.options, message, recipient, function(err, response, attemptedRegTokens) {
         if (err) {
             if (typeof err === 'number' && err > 399 && err < 500) {
                 debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
@@ -125,7 +125,7 @@ function updateResponseMetaData(response, retriedResponse, unsentRegTokens) {
     response.failure -= unsentRegTokens.length - retriedResponse.failure;
 }
 
-Sender.prototype.sendNoRetry = function(message, recipient, callback) {
+function sendNoRetry(key, options, message, recipient, callback) {
     if(!callback) {
         callback = function() {};
     }
@@ -139,11 +139,11 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
         var request_options = defaultsDeep({
             method: 'POST',
             headers: {
-                'Authorization': 'key=' + this.key
+                'Authorization': 'key=' + key
             },
             uri: Constants.GCM_SEND_URI,
             json: body
-        }, this.options, {
+        }, options, {
             timeout: Constants.SOCKET_TIMEOUT
         });
 
@@ -165,8 +165,8 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
             }
             callback(null, resBodyJSON, body.registration_ids || [ body.to ]);
         });
-    }.bind(this));
-};
+    });
+}
 
 function getRequestBody(message, recipient, callback) {
     var body = cleanParams(message);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,7 +27,7 @@ Sender.prototype.send = function(message, recipient, options, callback) {
         return sendMessage(this.key, this.options, message, recipient, callback);
     }
 
-    sendMessageWithRetries(this, this.key, this.options, message, recipient, options, callback);
+    sendMessageWithRetries(this.key, this.options, message, recipient, options, callback);
 };
 
 function cleanOptions(options) {
@@ -55,14 +55,14 @@ function cleanOptions(options) {
     return options;
 }
 
-function sendMessageWithRetries(self, key, senderOptions, message, recipient, messageOptions, callback) {
+function sendMessageWithRetries(key, senderOptions, message, recipient, messageOptions, callback) {
     sendMessage(key, senderOptions, message, recipient, function(err, response, attemptedRegTokens) {
         if (err) {
             if (typeof err === 'number' && err > 399 && err < 500) {
                 debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
                 return callback(err);
             }
-            return retry(self, key, senderOptions, message, recipient, messageOptions, callback);
+            return retry(key, senderOptions, message, recipient, messageOptions, callback);
         }
         //TODO: Figure out why this case exists -- should it be removed?
         if(!response.results) {
@@ -78,7 +78,7 @@ function sendMessageWithRetries(self, key, senderOptions, message, recipient, me
 
             debug("Retrying " + unsentRegTokens.length + " unsent registration tokens");
 
-            retry(self, key, senderOptions, message, unsentRegTokens, messageOptions, function(err, retriedResponse) {
+            retry(key, senderOptions, message, unsentRegTokens, messageOptions, function(err, retriedResponse) {
                 if(err) {
                     return callback(null, response);
                 }
@@ -89,9 +89,9 @@ function sendMessageWithRetries(self, key, senderOptions, message, recipient, me
     });
 }
 
-function retry(self, key, senderOptions, message, recipient, messageOptions, callback) {
+function retry(key, senderOptions, message, recipient, messageOptions, callback) {
     return setTimeout(function() {
-        sendMessageWithRetries(self, key, senderOptions, message, recipient, {
+        sendMessageWithRetries(key, senderOptions, message, recipient, {
             retries: messageOptions.retries - 1,
             backoff: messageOptions.backoff * 2
         }, callback);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -64,6 +64,7 @@ function sendMessageWithRetries(self, key, senderOptions, message, recipient, me
             }
             return retry(self, key, senderOptions, message, recipient, messageOptions, callback);
         }
+        //TODO: Figure out why this case exists -- should it be removed?
         if(!response.results) {
             return callback(null, response);
         }

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -142,6 +142,9 @@ function sendMessageWithRetries(requestOptions, body, messageOptions, callback) 
 
 function retry(requestOptions, body, messageOptions, callback) {
     setTimeout(function() {
+        if(messageOptions.retries <= 1) {
+            return sendMessage(requestOptions, body, callback);
+        }
         sendMessageWithRetries(requestOptions, body, {
             retries: messageOptions.retries - 1,
             backoff: messageOptions.backoff * 2

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -395,28 +395,6 @@ describe('UNIT Sender', function () {
       setArgs(null, { statusCode: 200 }, {});
     });
 
-    it('should pass the message and the regToken to sendNoRetry on call', function () {
-      var sender = new Sender('myKey'),
-          message = { data: {} },
-          regToken = [24];
-      setArgs(null, {});
-      sender.send(message, regToken, 0, function () {});
-      expect(args.message).to.equal(message);
-      expect(args.reg_tokens).to.equal(regToken);
-      expect(args.tries).to.equal(1);
-    });
-
-    it('should pass the message and the regTokens to sendNoRetry on call', function () {
-      var sender = new Sender('myKey'),
-          message = { data: {} },
-          regTokens = [24, 34, 44];
-      setArgs(null, {});
-      sender.send(message, regTokens, 0, function () {});
-      expect(args.message).to.equal(message);
-      expect(args.reg_tokens).to.equal(regTokens);
-      expect(args.tries).to.equal(1);
-    });
-
     it('should pass the response into callback if successful for token', function () {
       var callback = sinon.spy(),
           response = { success: true },

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -38,7 +38,7 @@ describe('UNIT Sender', function () {
     });
   });
 
-  describe('sendNoRetry()', function () {
+  describe('send() without retries', function () {
     function setArgs(err, res, resBody) {
       args = {
         err: err,
@@ -59,7 +59,7 @@ describe('UNIT Sender', function () {
       };
       var sender = new Sender('mykey', options);
       var m = { data: {} };
-      sender.sendNoRetry(m, '', function () {});
+      sender.send(m, '', { retries: 0 }, function () {});
       setTimeout(function() {
         expect(args.options.proxy).to.equal(options.proxy);
         expect(args.options.maxSockets).to.equal(options.maxSockets);
@@ -80,7 +80,7 @@ describe('UNIT Sender', function () {
       };
       var sender = new Sender('mykey', options);
       var m = { data: {} };
-      sender.sendNoRetry(m, '', function () {});
+      sender.send(m, '', { retries: 0 }, function () {});
       setTimeout(function() {
         expect(args.options.method).to.not.equal(options.method);
         expect(args.options.headers).to.not.deep.equal(options.headers);
@@ -98,7 +98,7 @@ describe('UNIT Sender', function () {
       };
       var sender = new Sender('mykey', options);
       var m = { data: {} };
-      sender.sendNoRetry(m, '', function () {});
+      sender.send(m, '', { retries: 0 }, function () {});
       setTimeout(function() {
         expect(args.options.headers.Authorization).to.not.equal(options.headers.Auhtorization);
         done();
@@ -113,7 +113,7 @@ describe('UNIT Sender', function () {
       };
       var sender = new Sender('mykey', options);
       var m = { data: {} };
-      sender.sendNoRetry(m, '', function () {});
+      sender.send(m, '', { retries: 0 }, function () {});
       setTimeout(function() {
         expect(args.options.headers.Custom).to.deep.equal(options.headers.Custom);
         done();
@@ -128,7 +128,7 @@ describe('UNIT Sender', function () {
       };
       var sender = new Sender('mykey', options);
       var m = { data: {} };
-      sender.sendNoRetry(m, '', function () {});
+      sender.send(m, '', { retries: 0 }, function () {});
       setTimeout(function() {
         expect(args.options.strictSSL).to.be.an('undefined');
         done();
@@ -138,7 +138,7 @@ describe('UNIT Sender', function () {
     it('should set the API key of req object if passed in API key', function (done) {
       var sender = new Sender('myKey');
       var m = { data: {} };
-      sender.sendNoRetry(m, '', function () {});
+      sender.send(m, '', { retries: 0 }, function () {});
       setTimeout(function() {
         expect(args.options.headers.Authorization).to.equal('key=myKey');
         done();
@@ -148,7 +148,7 @@ describe('UNIT Sender', function () {
     it('should send a JSON object as the body of the request', function (done) {
       var sender = new Sender('mykey');
       var m = { collapseKey: 'Message', data: {} };
-      sender.sendNoRetry(m, '', function () {});
+      sender.send(m, '', { retries: 0 }, function () {});
       setTimeout(function() {
         expect(args.options.json).to.be.a('object');
         done();
@@ -166,7 +166,7 @@ describe('UNIT Sender', function () {
         }
       };
       var sender = new Sender('mykey');
-      sender.sendNoRetry(mess, '', function () {});
+      sender.send(mess, '', { retries: 0 }, function () {});
       setTimeout(function() {
         var body = args.options.json;
         expect(body.delay_while_idle).to.equal(mess.delay_while_idle);
@@ -190,7 +190,7 @@ describe('UNIT Sender', function () {
         unknown_property: "hello"
       };
       var sender = new Sender('mykey');
-      sender.sendNoRetry(mess, '', function () {});
+      sender.send(mess, '', { retries: 0 }, function () {});
       setTimeout(function() {
         var body = args.options.json;
         expect(body.delay_while_idle).to.equal(undefined);
@@ -206,7 +206,7 @@ describe('UNIT Sender', function () {
     it('should set the registration_ids to reg tokens implicitly passed in', function (done) {
       var sender = new Sender('myKey');
       var m = { data: {} };
-      sender.sendNoRetry(m, ["registration token 1", "registration token 2"], function () {});
+      sender.send(m, ["registration token 1", "registration token 2"], { retries: 0 }, function () {});
       setTimeout(function() {
         var body = args.options.json;
         expect(body.registration_ids).to.deep.equal(["registration token 1", "registration token 2"]);
@@ -218,7 +218,7 @@ describe('UNIT Sender', function () {
       var sender = new Sender('myKey');
       var m = { data: {} };
       var regTokens = ["registration token 1", "registration token 2"];
-      sender.sendNoRetry(m, { registrationIds: regTokens }, function () {});
+      sender.send(m, { registrationIds: regTokens }, { retries: 0 }, function () {});
       setTimeout(function() {
         var body = args.options.json;
         expect(body.registration_ids).to.deep.equal(regTokens);
@@ -230,7 +230,7 @@ describe('UNIT Sender', function () {
       var sender = new Sender('myKey');
       var m = { data: {} };
       var regTokens = ["registration token 1", "registration token 2"];
-      sender.sendNoRetry(m, { registrationTokens: regTokens }, function () {});
+      sender.send(m, { registrationTokens: regTokens }, { retries: 0 }, function () {});
       setTimeout(function() {
         var body = args.options.json;
         expect(body.registration_ids).to.deep.equal(regTokens);
@@ -241,7 +241,7 @@ describe('UNIT Sender', function () {
     it('should set the to field if a single reg (or other) token is passed in', function(done) {
       var sender = new Sender('myKey');
       var m = { data: {} };
-      sender.sendNoRetry(m, "registration token 1", function () {});
+      sender.send(m, "registration token 1", { retries: 0 }, function () {});
       setTimeout(function() {
         var body = args.options.json;
         expect(body.to).to.deep.equal("registration token 1");
@@ -254,7 +254,7 @@ describe('UNIT Sender', function () {
       var sender = new Sender('myKey');
       var m = { data: {} };
       var token = "registration token 1";
-      sender.sendNoRetry(m, token, function () {});
+      sender.send(m, token, { retries: 0 }, function () {});
       setTimeout(function() {
         var body = args.options.json;
         expect(body.to).to.deep.equal(token);
@@ -267,7 +267,7 @@ describe('UNIT Sender', function () {
       var sender = new Sender('myKey');
       var m = { data: {} };
       var token = "registration token 1";
-      sender.sendNoRetry(m, [ token ], function () {});
+      sender.send(m, [ token ], { retries: 0 }, function () {});
       setTimeout(function() {
         var body = args.options.json;
         expect(body.registration_ids).to.deep.equal([ token ]);
@@ -279,7 +279,7 @@ describe('UNIT Sender', function () {
     it('should pass an error into callback if recipient is an empty object', function (done) {
       var callback = sinon.spy();
       var sender = new Sender('myKey');
-      sender.sendNoRetry({}, {}, callback);
+      sender.send({}, {}, { retries: 0 }, callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.args[0][0]).to.be.a('object');
@@ -290,7 +290,7 @@ describe('UNIT Sender', function () {
     it('should pass an error into callback if no recipient provided', function (done) {
       var callback = sinon.spy();
       var sender = new Sender('myKey');
-      sender.sendNoRetry({}, [], callback);
+      sender.send({}, [], { retries: 0 }, callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.args[0][0]).to.be.a('object');
@@ -303,7 +303,7 @@ describe('UNIT Sender', function () {
           sender = new Sender('myKey');
       setArgs('an error', {}, {});
       var m = { data: {} };
-      sender.sendNoRetry(m, '', callback);
+      sender.send(m, '', { retries: 0 }, callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.calledWith('an error')).to.be.ok;
@@ -316,7 +316,7 @@ describe('UNIT Sender', function () {
           sender = new Sender('myKey');
       setArgs(null, { statusCode: 500 }, {});
       var m = { data: {} };
-      sender.sendNoRetry(m, '', callback);
+      sender.send(m, '', { retries: 0 }, callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.args[0][0]).to.equal(500);
@@ -329,7 +329,7 @@ describe('UNIT Sender', function () {
           sender = new Sender('myKey');
       setArgs(null, { statusCode: 401 }, {});
       var m = { data: {} };
-      sender.sendNoRetry(m, '', callback);
+      sender.send(m, '', { retries: 0 }, callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.args[0][0]).to.equal(401);
@@ -342,7 +342,7 @@ describe('UNIT Sender', function () {
           sender = new Sender('myKey');
       setArgs(null, { statusCode: 400 }, {});
       var m = { data: {} };
-      sender.sendNoRetry(m, '', callback);
+      sender.send(m, '', { retries: 0 }, callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.args[0][0]).to.equal(400);
@@ -356,7 +356,7 @@ describe('UNIT Sender', function () {
           parseError = {error: 'Failed to parse JSON'};
       setArgs(parseError, null, null);
       var m = { data: {} };
-      sender.sendNoRetry(m, '', callback);
+      sender.send(m, '', { retries: 0 }, callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.args[0][0]).to.deep.equal(parseError);
@@ -373,7 +373,7 @@ describe('UNIT Sender', function () {
       var sender = new Sender('myKey');
       setArgs(null, { statusCode: 200 }, resBody);
       var m = { data: {} };
-      sender.sendNoRetry(m, '', callback);
+      sender.send(m, '', { retries: 0 }, callback);
       setTimeout(function() {
         expect(callback.calledOnce).to.be.ok;
         expect(callback.args[0][1]).to.deep.equal(resBody);

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -28,19 +28,6 @@ describe('UNIT Sender', function () {
       expect(sender).to.not.be.undefined;
       expect(sender).to.be.instanceOf(gcm);
     });
-
-    it('should create a Sender with key and options passed in', function () {
-      var options = {
-        proxy: 'http://myproxy.com',
-        maxSockets: 100,
-        timeout: 100
-      };
-      var key = 'myAPIKey',
-          sender = new gcm(key, options);
-      expect(sender).to.be.instanceOf(gcm);
-      expect(sender.key).to.equal(key);
-      expect(sender.options).to.deep.equal(options);
-    });
   });
 
   describe('send() without retries', function () {
@@ -56,7 +43,7 @@ describe('UNIT Sender', function () {
         setArgs(null, { statusCode: 200 }, {});
     });
 
-    it('should set proxy, maxSockets, timeout and/or strictSSL of req object if passed into constructor', function (done) {
+    it('should set key, proxy, maxSockets, timeout and/or strictSSL of req object if passed into constructor', function (done) {
       var options = {
         proxy: 'http://myproxy.com',
         maxSockets: 100,
@@ -67,6 +54,7 @@ describe('UNIT Sender', function () {
       var m = { data: {} };
       sender.send(m, '', { retries: 0 }, function () {});
       setTimeout(function() {
+        expect(args.options.headers["Authorization"]).to.equal("key=mykey");
         expect(args.options.proxy).to.equal(options.proxy);
         expect(args.options.maxSockets).to.equal(options.maxSockets);
         expect(args.options.timeout).to.equal(options.timeout);

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -45,7 +45,7 @@ describe('UNIT Sender', function () {
         res: res,
         resBody: resBody
       };
-    };
+    }
     before(function() {
         setArgs(null, { statusCode: 200 }, {});
     });
@@ -383,43 +383,16 @@ describe('UNIT Sender', function () {
   });
 
   describe('send()', function () {
-    var restore = {};
-    // Set args passed into sendNoRetry
-    function setArgs(err, response) {
+    function setArgs(err, res, resBody) {
       args = {
         err: err,
-        response: response,
-        tries: 0
+        res: res,
+        resBody: resBody
       };
-    };
+    }
 
-    before( function () {
-      restore.sendNoRetry = Sender.prototype.sendNoRetry;
-      Sender.prototype.sendNoRetry = function (message, reg_tokens, callback) {
-        args.message = message;
-        args.reg_tokens = reg_tokens;
-        args.tries++;
-        var nextResponse;
-        if(!args.response) {
-          nextResponse = args.response;
-        }
-        else if(args.response.length > 1) {
-          nextResponse = args.response.slice(0,1)[0];
-          args.response = args.response.slice(1,args.response.length);
-        }
-        else if(args.response.length == 1) {
-          args.response = args.response[0];
-          nextResponse = args.response;
-        }
-        else {
-          nextResponse = args.response;
-        }
-        callback( args.err, nextResponse, args.reg_tokens );
-      };
-    });
-
-    after( function () {
-      Sender.prototype.sendNoRetry = restore.sendNoRetry;
+    before(function() {
+      setArgs(null, { statusCode: 200 }, {});
     });
 
     it('should pass the message and the regToken to sendNoRetry on call', function () {

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -208,30 +208,6 @@ describe('UNIT Sender', function () {
       }, 10);
     });
 
-    it('should set the registration_ids to reg tokens explicitly passed in', function (done) {
-      var sender = new Sender('myKey');
-      var m = { data: {} };
-      var regTokens = ["registration token 1", "registration token 2"];
-      sender.send(m, { registrationIds: regTokens }, { retries: 0 }, function () {});
-      setTimeout(function() {
-        var body = args.options.json;
-        expect(body.registration_ids).to.deep.equal(regTokens);
-        done();
-      }, 10);
-    });
-
-    it('should set the registration_ids to reg tokens explicitly passed in', function (done) {
-      var sender = new Sender('myKey');
-      var m = { data: {} };
-      var regTokens = ["registration token 1", "registration token 2"];
-      sender.send(m, { registrationTokens: regTokens }, { retries: 0 }, function () {});
-      setTimeout(function() {
-        var body = args.options.json;
-        expect(body.registration_ids).to.deep.equal(regTokens);
-        done();
-      }, 10);
-    });
-
     it('should set the to field if a single reg (or other) token is passed in', function(done) {
       var sender = new Sender('myKey');
       var m = { data: {} };

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -395,48 +395,60 @@ describe('UNIT Sender', function () {
       setArgs(null, { statusCode: 200 }, {});
     });
 
-    it('should pass the response into callback if successful for token', function () {
+    it('should pass the response into callback if successful for token', function (done) {
       var callback = sinon.spy(),
           response = { success: true },
           sender = new Sender('myKey');
       setArgs(null, response);
       sender.send({}, [1], 0, callback);
-      expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][1]).to.equal(response);
-      expect(args.tries).to.equal(1);
+      setTimeout(function() {
+        expect(callback.calledOnce).to.be.ok;
+        expect(callback.args[0][1]).to.equal(response);
+        expect(args.tries).to.equal(1);
+        done();
+      }, 10);
     });
 
-    it('should pass the response into callback if successful for tokens', function () {
+    it('should pass the response into callback if successful for tokens', function (done) {
       var callback = sinon.spy(),
           response = { success: true },
           sender = new Sender('myKey');
       setArgs(null, response);
       sender.send({}, [1, 2, 3], 0, callback);
-      expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][1]).to.equal(response);
-      expect(args.tries).to.equal(1);
+      setTimeout(function() {
+        expect(callback.calledOnce).to.be.ok;
+        expect(callback.args[0][1]).to.equal(response);
+        expect(args.tries).to.equal(1);
+        done();
+      }, 10);
     });
 
-    it('should pass the error into callback if failure and no retry for token', function () {
+    it('should pass the error into callback if failure and no retry for token', function (done) {
       var callback = sinon.spy(),
           error = 'my error',
           sender = new Sender('myKey');
       setArgs(error);
       sender.send({}, [1], 0, callback);
-      expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][0]).to.equal(error);
-      expect(args.tries).to.equal(1);
+      setTimeout(function() {
+        expect(callback.calledOnce).to.be.ok;
+        expect(callback.args[0][0]).to.equal(error);
+        expect(args.tries).to.equal(1);
+        done();
+      }, 10);
     });
 
-    it('should pass the error into callback if failure and no retry for tokens', function () {
+    it('should pass the error into callback if failure and no retry for tokens', function (done) {
       var callback = sinon.spy(),
           error = 'my error',
           sender = new Sender('myKey');
       setArgs(error);
       sender.send({}, [1, 2, 3], 0, callback);
-      expect(callback.calledOnce).to.be.ok;
-      expect(callback.args[0][0]).to.equal(error);
-      expect(args.tries).to.equal(1);
+      setTimeout(function() {
+        expect(callback.calledOnce).to.be.ok;
+        expect(callback.args[0][0]).to.equal(error);
+        expect(args.tries).to.equal(1);
+        done();
+      }, 10);
     });
 
     it('should retry number of times passed into call and do exponential backoff', function (done) {

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -422,36 +422,6 @@ describe('UNIT Sender', function () {
       Sender.prototype.sendNoRetry = restore.sendNoRetry;
     });
 
-    it('should pass reg tokens to sendNoRetry, even if it is an empty array', function (done) {
-      var emptyRegTokenArray = [];
-      var callback = function(error) {
-        expect(args.reg_tokens).to.equal(emptyRegTokenArray);
-        done();
-      };
-      var sender = new Sender('myKey');
-      sender.send({}, emptyRegTokenArray, 0, callback);
-    });
-
-    it('should pass reg tokens to sendNoRetry, even if it is an empty object', function (done) {
-      var emptyRegTokenObject = {};
-      var callback = function(error) {
-        expect(args.reg_tokens).to.equal(emptyRegTokenObject);
-        done();
-      };
-      var sender = new Sender('myKey');
-      sender.send({}, emptyRegTokenObject, 0, callback);
-    });
-
-    it('should pass reg tokens to sendNoRetry, even if some keys are invalid', function (done) {
-      var invalidRegTokenObject = { invalid: ['regToken'] };
-      var callback = function(error) {
-        expect(args.reg_tokens).to.equal(invalidRegTokenObject);
-        done();
-      };
-      var sender = new Sender('myKey');
-      sender.send({}, invalidRegTokenObject, 0, callback);
-    });
-
     it('should pass the message and the regToken to sendNoRetry on call', function () {
       var sender = new Sender('myKey'),
           message = { data: {} },


### PR DESCRIPTION
Note: this merges into v1 #238 

This refactors the sender code a whole bunch, and removes the previously exposed `sendNoRetry` method. The same effect can now be achieved with `send(msg, recipient, { retries: 0 }, callback)`.