### PR TITLE
fix: avoid possible prototype override protection bypass

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "debug": "^0.8.1",
     "lodash": "^3.10.1",
-    "request": "^2.27.0"
+    "request": "^2.81.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",


### PR DESCRIPTION
The library qs has vulnerabilities at version 6.3.1 qs is a dependency in this project through request I believe. request version ~2.81 has an updated version of qs (~6.4) without the vulnerability.

https://snyk.io/vuln/npm:qs:20170213