### PR TITLE
Support empty JSON response from FCM

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -34,7 +34,11 @@ Sender.prototype.send = function(message, recipient, options, callback) {
 
     this.sendNoRetry(message, recipient, function(err, response, attemptedRegTokens) {
         if (err) {
-            if (typeof err === 'number' && err > 399 && err < 500) {
+            // Attempt to determine HTTP status code
+            var statusCode = typeof err === 'number' ? err : (err.code || 0);
+
+            // 4xx error?
+            if (statusCode > 399 && statusCode < 500) {
                 debug("Error 4xx -- no use retrying. Something is wrong with the request (probably authentication?)");
                 return callback(err);
             }
@@ -165,6 +169,11 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
             if (res.statusCode !== 200) {
                 debug('Invalid request (' + res.statusCode + '): ' + resBodyJSON);
                 return callback(res.statusCode);
+            }
+            if (!resBodyJSON) {
+                debug('Empty response received (' + res.statusCode + ' ' + res.statusMessage + ')');
+                // Spoof error code 400 to avoid retrying the request
+                return callback({error: res.statusMessage, code: 400});
             }
             callback(null, resBodyJSON, body.registration_ids || [ body.to ]);
         });


### PR DESCRIPTION
Closes #292.

To avoid retrying a request with an empty response, I hard-coded the `4xx` error. 

@hypesystem Please review and let me know if there’s a better way to do this in your opinion.