### PR TITLE
Lock 'Request' package to 2.81.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-gcm",
   "description": "Easy interface for Google's Cloud Messaging service (now Firebase Cloud Messaging)",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "author": "Marcus Farkas <toothlessgear@finitebox.com>",
   "contributors": [
     "Marcus Farkas <toothlessgear@finitebox.com>",
@@ -69,7 +69,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "lodash": "^3.10.1",
-    "request": "^2.81.0"
+    "request": "2.81.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",


### PR DESCRIPTION
The 'Request' package maintainers have made a breaking change in version 2.82.0+ that no longer works on Node 0.10.x or 0.12.x. Since this package still specifies a supported engine of node 0.10.0, this PR locks the 'Request' package version to 2.81.0 forever.

While the "correct" solution here may be to not use node 0.x anymore since it's been deprecated, there are some packages and configurations that will break with change made in Request.