### PR TITLE
Adding `smallIcon` and `largeIcon` set exeptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ message.addNotification({
 
 Notice notification payload defined in [GCM Connection Server Reference](https://developers.google.com/cloud-messaging/server-ref#table1)
 
+**Note For Android:** When using `data` for sending a mixed notification (aka `message` key is on `data` object and no `notifcation` object) then you can specify `smallIcon` and `largeIcon` insted of `icon` for both icon types. `icon` will set `smallIcon` otherwise 
+
 ## Custom HTTP request options
 
 You can provide custom `request` options such as `proxy` and `timeout` for the HTTP request to the GCM API. For more information, refer to [the complete list of request options](https://github.com/request/request#requestoptions-callback). Note that the following options cannot be overriden: `method`, `uri`, `body`, as well as the following headers: `Authorization`, `Content-Type`, and `Content-Length`.


### PR DESCRIPTION
On android its possible to set `smallIcons` and `largeIcon` see details in [issue #330](https://github.com/ToothlessGear/node-gcm/issues/330) 
have not test natively with setting same on `notification` when tested on [React Native library](https://github.com/zo0r/react-native-push-notification) it did not worked