### PR TITLE
Update example to find  "bad" tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,7 @@ sender.send(message, { registrationTokens: registrationTokens }, 10, function (e
 //    The results-array does not contain any tokens!
 // A: The array of tokens used for sending will match the array of results, so you can cross-check them.
 sender.send(message, { registrationTokens: registrationTokens }, function (err, response) {  
-  var failed_tokens = response.results                           // Array with result for each token we messaged
-    .map((res, i) => res.error ? registrationTokens[i] : null)   // If there's any kind of error, 
-                                                                 // pick _the token_ from the _other_ array
-    .filter(token => token);                                     // Remove all the null values
+  var failed_tokens = registrationTokens.filter((token, i) => response[i].error != null);
   console.log('These tokens are no longer ok:', failed_tokens);
 });
 ```


### PR DESCRIPTION
Failed tokens can be found with a single `filter` operation over the `registrationTokens` using the 1:1 mapping with response data. Earlier example used `map` + `filter` to achieve the same result.