### PR TITLE
fix: Gcm InternalServerError should also be retied with exponential-back-off.

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -33,7 +33,8 @@ var Constants = {
     'ERROR_NOT_REGISTERED' : 'NotRegistered',
     'ERROR_MESSAGE_TOO_BIG' : 'MessageTooBig',
     'ERROR_MISSING_COLLAPSE_KEY' : 'MissingCollapseKey',
-    'ERROR_UNAVAILABLE' : 'Unavailable'
+    'ERROR_UNAVAILABLE' : 'Unavailable',
+    'ERROR_INTERNAL_SERVER_ERROR' : 'InternalServerError'
 
     /** END DEPRECATED **/
 };

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -106,7 +106,7 @@ function checkForBadTokens(results, originalRecipients, callback) {
     var unsentRegTokens = [];
     var regTokenPositionMap = [];
     for (var i = 0; i < results.length; i++) {
-        if (results[i].error === 'Unavailable') {
+        if (results[i].error === 'Unavailable' || results[i].error === 'InternalServerError') {
             regTokenPositionMap.push(i);
             unsentRegTokens.push(originalRecipients[i]);
         }

--- a/test/unit/senderSpec.js
+++ b/test/unit/senderSpec.js
@@ -703,6 +703,22 @@ describe('UNIT Sender', function () {
       }, callback);
     });
 
+    it('should retry if some regTokens were failed with InternalServerError', function (done) {
+      var callback = function () {
+        expect(args.tries).to.equal(3);
+        // Last call of sendNoRetry should be for only failed regTokens
+        expect(args.reg_tokens.length).to.equal(1);
+        expect(args.reg_tokens[0]).to.equal(3);
+        done();
+      };
+      var sender = new Sender('myKey');
+      setArgs(null, [{ results: [{}, { error: 'InternalServerError' }, { error: 'InternalServerError' }]}, { results: [ {}, { error: 'InternalServerError' } ] }, { results: [ {} ] } ]);
+      sender.send({ data: {}}, [1,2,3], {
+        retries: 5,
+        backoff: 100
+      }, callback);
+    });
+
     it('should retry all regTokens in event of an error', function (done) {
       var start = new Date();
       var callback = function () {
@@ -731,6 +747,22 @@ describe('UNIT Sender', function () {
       sender.send({ data: {}}, [1,2,3], 3, callback);
     });
 
+    it('should update the failures and successes correctly when retrying for InternalServerError response', function (done) {
+      var callback = function(error, response) {
+        expect(error).to.equal(null);
+        expect(response.canonical_ids).to.equal(1);
+        expect(response.success).to.equal(2);
+        expect(response.failure).to.equal(0);
+        done();
+      };
+      var sender = new Sender('myKey');
+      setArgs(null, [
+        { success: 1, failure: 2, canonical_ids: 0, results: [ {}, { error: 'InternalServerError' }, { error: 'InternalServerError' } ] },
+        { success: 1, canonical_ids: 1, failure: 0, results: [ {}, {} ] }
+      ]);
+      sender.send({ data: {}}, [1,2,3], 3, callback);
+    });
+
     it('should update the failures and successes correctly when retrying and failing some', function (done) {
       var callback = function(error, response) {
         expect(error).to.equal(null);
@@ -744,6 +776,26 @@ describe('UNIT Sender', function () {
         { success: 0, failure: 3, canonical_ids: 0, results: [ { error: 'Unavailable' }, { error: 'Unavailable' }, { error: 'Unavailable' } ] },
         { success: 1, canonical_ids: 0, failure: 2, results: [ { error: 'Unavailable' }, { error: 'Unavailable' }, {} ] },
         { success: 0, canonical_ids: 0, failure: 2, results: [ { error: 'Unavailable' }, { error: 'Unavailable' } ] }
+      ]);
+      sender.send({ data: {}}, [1,2,3], {
+        retries: 3,
+        backoff: 100
+      }, callback);
+    });
+
+    it('should update the failures and successes correctly when retrying and failing some with InternalServerError response', function (done) {
+      var callback = function(error, response) {
+        expect(error).to.equal(null);
+        expect(response.canonical_ids).to.equal(0);
+        expect(response.success).to.equal(1);
+        expect(response.failure).to.equal(2);
+        done();
+      };
+      var sender = new Sender('myKey');
+      setArgs(null, [
+        { success: 0, failure: 3, canonical_ids: 0, results: [ { error: 'InternalServerError' }, { error: 'InternalServerError' }, { error: 'InternalServerError' } ] },
+        { success: 1, canonical_ids: 0, failure: 2, results: [ { error: 'InternalServerError' }, { error: 'InternalServerError' }, {} ] },
+        { success: 0, canonical_ids: 0, failure: 2, results: [ { error: 'InternalServerError' }, { error: 'InternalServerError' } ] }
       ]);
       sender.send({ data: {}}, [1,2,3], {
         retries: 3,


### PR DESCRIPTION
as per the [Firebase Error Code](https://firebase.google.com/docs/cloud-messaging/http-server-ref#error-codes) "InternalServerError" should be retired similar to "Unavailable" error.