### PR TITLE
Rename occurrences of GCM to FCM in README

### DIFF
--- a/lib/message-options.js
+++ b/lib/message-options.js
@@ -1,13 +1,13 @@
 /**
  * This module defines all the arguments that may be passed to a message.
- * 
+ *
  * Each argument may contain a field `__argName`, if the name of the field
  * should be different when sent to the server.
- * 
+ *
  * The argument may also contain a field `__argType`, if the given
  * argument must be of that type. The types are the strings resulting from
  * calling `typeof <arg>` where `<arg>` is the argument.
- * 
+ *
  * Other than that, the arguments are expected to follow the indicated
  * structure.
  */
@@ -48,6 +48,11 @@ module.exports = {
         __argType: "object"
     },
     notification: {
+        __argType: "object"
+        //TODO: There are a lot of very specific arguments that could
+        //      be indicated here.
+    },
+    fcm_options: {
         __argType: "object"
         //TODO: There are a lot of very specific arguments that could
         //      be indicated here.


### PR DESCRIPTION
- Allow setting `fcm_options` to add `analytics_label` for Firebase analytics.