### PR TITLE
Add fcm_options as allowed params to message object

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ This is due to [a restriction](https://firebase.google.com/docs/cloud-messaging/
 |dryRun|Optional, JSON boolean|This parameter, when set to true, allows developers to test a request without actually sending a message.|
 |data|Optional, JSON object|This parameter specifies the custom key-value pairs of the message's payload.|
 |notification|Optional, JSON object|This parameter specifies the predefined, user-visible key-value pairs of the notification payload. See "Notification payload option table" below for more details.|
-|fcm_options|Optional, JSON object|This parameter is used to pass FCM specific options as outlined (here)[https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#FcmOptions]|
+|fcm_options|Optional, JSON object|This parameter is used to pass FCM specific options as outlined [here](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#FcmOptions)|
 
 ## Notification usage
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ sender.send(message, { registrationTokens: registrationTokens }, 10, function (e
   else    console.log(response);
 });
 
-// Q: I need to remove all "bad" token from my database, how do I do that? 
+// Q: I need to remove all "bad" token from my database, how do I do that?
 //    The results-array does not contain any tokens!
 // A: The array of tokens used for sending will match the array of results, so you can cross-check them.
-sender.send(message, { registrationTokens: registrationTokens }, function (err, response) {  
+sender.send(message, { registrationTokens: registrationTokens }, function (err, response) {
   var failed_tokens = registrationTokens.filter((token, i) => response[i].error != null);
   console.log('These tokens are no longer ok:', failed_tokens);
 });
@@ -167,6 +167,7 @@ This is due to [a restriction](https://firebase.google.com/docs/cloud-messaging/
 |dryRun|Optional, JSON boolean|This parameter, when set to true, allows developers to test a request without actually sending a message.|
 |data|Optional, JSON object|This parameter specifies the custom key-value pairs of the message's payload.|
 |notification|Optional, JSON object|This parameter specifies the predefined, user-visible key-value pairs of the notification payload. See "Notification payload option table" below for more details.|
+|fcm_options|Optional, JSON object|This parameter is used to pass FCM specific options as outlined (here)[https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#FcmOptions]|
 
 ## Notification usage
 

--- a/lib/message-options.js
+++ b/lib/message-options.js
@@ -1,13 +1,13 @@
 /**
  * This module defines all the arguments that may be passed to a message.
- * 
+ *
  * Each argument may contain a field `__argName`, if the name of the field
  * should be different when sent to the server.
- * 
+ *
  * The argument may also contain a field `__argType`, if the given
  * argument must be of that type. The types are the strings resulting from
  * calling `typeof <arg>` where `<arg>` is the argument.
- * 
+ *
  * Other than that, the arguments are expected to follow the indicated
  * structure.
  */
@@ -51,5 +51,8 @@ module.exports = {
         __argType: "object"
         //TODO: There are a lot of very specific arguments that could
         //      be indicated here.
+    },
+    fcm_options: {
+        __argType: "object"
     }
 };


### PR DESCRIPTION
- As per the Firebase [docs](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages?authuser=0#androidfcmoptions), `fcm_options` is a new-ish parameter to allow setting a label on push notification messages. The message options does not have this as a valid config so setting it on the message will be ignored. This will allow it as a valid option.