### PR TITLE
fix: handle non-http errors correctly (#375)

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -173,14 +173,16 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
             (err) => {
                 const { response: res } = err;
 
-                if (res.status === 401) {
-                    debug('Unauthorized (401). Check that your API token is correct.');
-                    return callback(res.status);
-                }
+                if (res) {
+                    if (res.status === 401) {
+                        debug('Unauthorized (401). Check that your API token is correct.');
+                        return callback(res.status);
+                    }
 
-                if (res.status >= 500) {
-                    debug('GCM service is unavailable (500)');
-                    return callback(res.status);
+                    if (res.status >= 500) {
+                        debug('GCM service is unavailable (500)');
+                        return callback(res.status);
+                    }
                 }
 
                 return callback(err);


### PR DESCRIPTION
Added a check for `result` property present in error, otherwise call back with error instance.